### PR TITLE
Revert "Fix crash that happened if you were to edit the materials in …

### DIFF
--- a/AtlusGfdLib/Material.cs
+++ b/AtlusGfdLib/Material.cs
@@ -239,7 +239,7 @@ namespace AtlusGfdLibrary
             ValidateMapFlags( DetailMap,     MaterialFlags.HasDetailMap );
             ValidateMapFlags( ShadowMap,     MaterialFlags.HasShadowMap );
 
-            if ( Attributes == null || Attributes.Count == 0 )
+            if ( Attributes == null )
             {
                 mFlags &= ~MaterialFlags.HasAttributes;
             }


### PR DESCRIPTION
…the GUI"

This reverts commit e047a038e1351d07da400126d6134a1b159d87d3.

This causes an access violation ingame when a material is replaced or edited. I've experienced no unexpected crashes ingame (or with AtlusGfdEditor) since reverting this commit for my local build months ago. 