### PR TITLE
add tmx support

### DIFF
--- a/GFDLibrary/Textures/Texture.cs
+++ b/GFDLibrary/Textures/Texture.cs
@@ -115,6 +115,8 @@ namespace GFDLibrary.Textures
     {
         Invalid = 0,
         DDS = 1,
+		TGA = 2,
+		TMX = 3,
         GXT = 6,
         GNF = 9
     }

--- a/GFDLibrary/Textures/TextureDecoder.cs
+++ b/GFDLibrary/Textures/TextureDecoder.cs
@@ -119,6 +119,8 @@ namespace GFDLibrary.Textures
             {
                 case TextureFormat.DDS:
                     return DecodeDDS( data );
+                case TextureFormat.TMX:
+                    return DecodeTMX( data );
                 case TextureFormat.GXT:
                     return DecodeGXT( data );
                 case TextureFormat.GNF:
@@ -177,6 +179,12 @@ namespace GFDLibrary.Textures
             return new Bitmap( bitmapStream );
         }
 
+        private static Bitmap DecodeTMX( byte[] data )
+        {
+            var tmx = new Scarlet.IO.ImageFormats.TMX();
+            tmx.Open( new MemoryStream( data ), Scarlet.IO.Endian.LittleEndian );
+            return tmx.GetBitmap();
+        }
         private static Bitmap DecodeGXT( byte[] data )
         {
             var gxt = new Scarlet.IO.ImageFormats.GXT();


### PR DESCRIPTION
adds actual tmx textures support with scarlet (can't use replace tho cuz that's just made to work with just dds) 

i would also add tga (format 2) but scarlet doesn't support it, and since you're using a god knows how old commit of an unmaintained repo instead of your own fork idk how to add tga support to that

![image](https://user-images.githubusercontent.com/39583006/151694375-596a9ca5-ab47-4625-b347-0123ea347d79.png)
![image](https://user-images.githubusercontent.com/39583006/151694376-d4ecb283-4afe-4871-abb7-cac5ae228ea6.png)
