### PR TITLE
Dark mode, updated shaders, resizable form layout, bump to v0.6.7

### DIFF
--- a/GFDStudio.sln
+++ b/GFDStudio.sln
@@ -28,6 +28,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TgaDecoderTest", "tga-decoder-cs\TgaDecoderTest.csproj", "{4928554C-ACFF-4D52-885E-F76781DCD4EC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GrayIris.Utilities", "..\yet-another-tab-control\GrayIris.Utilities.csproj", "{38D57FE6-C75F-4B05-9E4F-D02A48CAA21E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -120,6 +122,18 @@ Global
 		{4928554C-ACFF-4D52-885E-F76781DCD4EC}.Release|x64.ActiveCfg = Release|x86
 		{4928554C-ACFF-4D52-885E-F76781DCD4EC}.Release|x86.ActiveCfg = Release|x86
 		{4928554C-ACFF-4D52-885E-F76781DCD4EC}.Release|x86.Build.0 = Release|x86
+		{38D57FE6-C75F-4B05-9E4F-D02A48CAA21E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{38D57FE6-C75F-4B05-9E4F-D02A48CAA21E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{38D57FE6-C75F-4B05-9E4F-D02A48CAA21E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{38D57FE6-C75F-4B05-9E4F-D02A48CAA21E}.Debug|x64.Build.0 = Debug|Any CPU
+		{38D57FE6-C75F-4B05-9E4F-D02A48CAA21E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{38D57FE6-C75F-4B05-9E4F-D02A48CAA21E}.Debug|x86.Build.0 = Debug|Any CPU
+		{38D57FE6-C75F-4B05-9E4F-D02A48CAA21E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{38D57FE6-C75F-4B05-9E4F-D02A48CAA21E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{38D57FE6-C75F-4B05-9E4F-D02A48CAA21E}.Release|x64.ActiveCfg = Release|Any CPU
+		{38D57FE6-C75F-4B05-9E4F-D02A48CAA21E}.Release|x64.Build.0 = Release|Any CPU
+		{38D57FE6-C75F-4B05-9E4F-D02A48CAA21E}.Release|x86.ActiveCfg = Release|Any CPU
+		{38D57FE6-C75F-4B05-9E4F-D02A48CAA21E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -131,6 +145,7 @@ Global
 		{C4429977-DF58-4829-B3B1-23F9FE673F60} = {FB118C81-7E1F-4D89-96D9-12A254AFE8D5}
 		{C6F2DA05-2927-466D-9087-AB36B5D27FC9} = {FB118C81-7E1F-4D89-96D9-12A254AFE8D5}
 		{FB118C81-7E1F-4D89-96D9-12A254AFE8D5} = {D8A2A445-B72A-4D3C-BE12-A4205A55C89B}
+		{38D57FE6-C75F-4B05-9E4F-D02A48CAA21E} = {99026BAA-1FC1-4F12-9C8E-B29F5629DA2D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BD633E5D-8912-4A36-B69C-E40CF3BA12B2}

--- a/GFDStudio/App.config
+++ b/GFDStudio/App.config
@@ -3,6 +3,9 @@
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
+	<System.Windows.Forms.ApplicationConfigurationSection>
+		<add key="DpiAwareness" value="PerMonitorV2" />
+	</System.Windows.Forms.ApplicationConfigurationSection>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>

--- a/GFDStudio/GFDStudio.csproj
+++ b/GFDStudio/GFDStudio.csproj
@@ -4,19 +4,23 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
-    <Version>0.6.6</Version>
+    <Version>0.6.7</Version>
     <Authors>TGE</Authors>
     <Company>TGE</Company>
     <ApplicationIcon>app_data\icons\main_icon.ico</ApplicationIcon>
+    <StartupObject>GFDStudio.Program</StartupObject>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="DarkModeUI" Version="3.1.0" />
+    <PackageReference Include="MetroSet_UI" Version="2.0.0" />
     <PackageReference Include="Ookii.Dialogs.Wpf" Version="3.0.1" />
     <PackageReference Include="OpenTK" Version="3.1.0" />
     <PackageReference Include="OpenTK.GLControl" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\yet-another-tab-control\GrayIris.Utilities.csproj" />
     <ProjectReference Include="..\GFDLibrary.Rendering.OpenGL\GFDLibrary.Rendering.OpenGL.csproj" />
     <ProjectReference Include="..\GFDLibrary\GFDLibrary.NET6.csproj" />
   </ItemGroup>

--- a/GFDStudio/GUI/Controls/ModelViewControl.cs
+++ b/GFDStudio/GUI/Controls/ModelViewControl.cs
@@ -39,7 +39,7 @@ namespace GFDStudio.GUI.Controls
         private GLShaderProgram mLineShader;
         private int mGridVertexArrayID;
         private GLBuffer<Vector3> mGridVertexBuffer;
-        private int mGridSize = 2000;
+        private int mGridSize = 96;
         private int mGridSpacing = 16;
         private float mGridMinZ;
 
@@ -354,7 +354,7 @@ namespace GFDStudio.GUI.Controls
             mLineShader.Use();
             mLineShader.SetUniform( "uView", view );
             mLineShader.SetUniform( "uProjection", projection );
-            mLineShader.SetUniform( "uColor", new Vector4( 0.15f, 0.15f, 0.15f, 1f ) );
+            mLineShader.SetUniform( "uColor", new Vector4( 50.15f, 50.15f, 50.15f, 1f ) );
             mLineShader.SetUniform( "uMinZ", mGridMinZ );
 
             GL.BindVertexArray( mGridVertexArrayID );
@@ -394,7 +394,7 @@ namespace GFDStudio.GUI.Controls
         /// </summary>
         private void InitializeGLRenderState()
         {
-            GL.ClearColor( Color.LightGray );
+            GL.ClearColor( System.Drawing.Color.FromArgb( 60, 63, 65 ) );
             GL.FrontFace( FrontFaceDirection.Ccw );
             GL.CullFace( CullFaceMode.Back );
             GL.Enable( EnableCap.CullFace );

--- a/GFDStudio/GUI/DataViewNodes/MaterialDictionaryViewNode.cs
+++ b/GFDStudio/GUI/DataViewNodes/MaterialDictionaryViewNode.cs
@@ -33,7 +33,7 @@ namespace GFDStudio.GUI.DataViewNodes
                 Data.Add( new Material( "New material" ) );
                 InitializeView( true );
             } );
-            RegisterCustomHandler("Convert to", "Material preset (All)", () => { ConvertAllToMaterialPreset(); });
+            //RegisterCustomHandler("Convert to", "Material preset (All)", () => { ConvertAllToMaterialPreset(); });
             RegisterCustomHandler( "Export", "All", () =>
             {
                 var dialog = new VistaFolderBrowserDialog();

--- a/GFDStudio/GUI/Forms/CreateTextureMapDialog.Designer.cs
+++ b/GFDStudio/GUI/Forms/CreateTextureMapDialog.Designer.cs
@@ -1,6 +1,9 @@
-﻿namespace GFDStudio.GUI.Forms
+﻿using MetroSet_UI.Controls;
+using MetroSet_UI.Forms;
+
+namespace GFDStudio.GUI.Forms
 {
-    partial class CreateTextureMapDialog
+    partial class CreateTextureMapDialog : MetroSetForm
     {
         /// <summary>
         /// Required designer variable.
@@ -28,124 +31,163 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.label1 = new System.Windows.Forms.Label();
-            this.comboBox1 = new System.Windows.Forms.ComboBox();
-            this.CancelButton = new System.Windows.Forms.Button();
-            this.OKButton = new System.Windows.Forms.Button();
-            this.label2 = new System.Windows.Forms.Label();
-            this.textBox1 = new System.Windows.Forms.TextBox();
-            this.tableLayoutPanel1.SuspendLayout();
-            this.SuspendLayout();
+            tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            label2 = new MetroSetLabel();
+            label1 = new MetroSetLabel();
+            comboBox1 = new System.Windows.Forms.ComboBox();
+            textBox1 = new MetroSetTextBox();
+            CancelButton = new System.Windows.Forms.Button();
+            OKButton = new System.Windows.Forms.Button();
+            tableLayoutPanel1.SuspendLayout();
+            SuspendLayout();
             // 
             // tableLayoutPanel1
             // 
-            this.tableLayoutPanel1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.tableLayoutPanel1.ColumnCount = 2;
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 18.88412F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 81.11588F));
-            this.tableLayoutPanel1.Controls.Add(this.label2, 0, 1);
-            this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this.comboBox1, 1, 0);
-            this.tableLayoutPanel1.Controls.Add(this.textBox1, 1, 1);
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(12, 12);
-            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            this.tableLayoutPanel1.RowCount = 2;
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(219, 71);
-            this.tableLayoutPanel1.TabIndex = 0;
-            // 
-            // label1
-            // 
-            this.label1.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(7, 11);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(31, 13);
-            this.label1.TabIndex = 3;
-            this.label1.Text = "Type";
-            // 
-            // comboBox1
-            // 
-            this.comboBox1.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.comboBox1.FormattingEnabled = true;
-            this.comboBox1.Items.AddRange(new object[] {
-            "Diffuse Map",
-            "Normal Map",
-            "Specular Map",
-            "Reflection Map",
-            "Highlight Map",
-            "Glow Map",
-            "Night Map",
-            "Detail Map",
-            "Shadow Map"});
-            this.comboBox1.Location = new System.Drawing.Point(44, 7);
-            this.comboBox1.Name = "comboBox1";
-            this.comboBox1.Size = new System.Drawing.Size(169, 21);
-            this.comboBox1.TabIndex = 4;
-            // 
-            // CancelButton
-            // 
-            this.CancelButton.Anchor = System.Windows.Forms.AnchorStyles.None;
-            this.CancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.CancelButton.Location = new System.Drawing.Point(36, 91);
-            this.CancelButton.Margin = new System.Windows.Forms.Padding(10);
-            this.CancelButton.Name = "CancelButton";
-            this.CancelButton.Size = new System.Drawing.Size(75, 23);
-            this.CancelButton.TabIndex = 1;
-            this.CancelButton.Text = "Cancel";
-            this.CancelButton.UseVisualStyleBackColor = true;
-            // 
-            // OKButton
-            // 
-            this.OKButton.Anchor = System.Windows.Forms.AnchorStyles.None;
-            this.OKButton.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.OKButton.Location = new System.Drawing.Point(131, 91);
-            this.OKButton.Margin = new System.Windows.Forms.Padding(10);
-            this.OKButton.Name = "OKButton";
-            this.OKButton.Size = new System.Drawing.Size(75, 23);
-            this.OKButton.TabIndex = 2;
-            this.OKButton.Text = "OK";
-            this.OKButton.UseVisualStyleBackColor = true;
-            this.OKButton.Click += new System.EventHandler(this.OKButton_Click);
+            tableLayoutPanel1.Anchor =    System.Windows.Forms.AnchorStyles.Top  |  System.Windows.Forms.AnchorStyles.Left   |  System.Windows.Forms.AnchorStyles.Right  ;
+            tableLayoutPanel1.ColumnCount = 2;
+            tableLayoutPanel1.ColumnStyles.Add( new System.Windows.Forms.ColumnStyle( System.Windows.Forms.SizeType.Percent, 18.88412F ) );
+            tableLayoutPanel1.ColumnStyles.Add( new System.Windows.Forms.ColumnStyle( System.Windows.Forms.SizeType.Percent, 81.11588F ) );
+            tableLayoutPanel1.Controls.Add( label2, 0, 1 );
+            tableLayoutPanel1.Controls.Add( label1, 0, 0 );
+            tableLayoutPanel1.Controls.Add( comboBox1, 1, 0 );
+            tableLayoutPanel1.Controls.Add( textBox1, 1, 1 );
+            tableLayoutPanel1.Location = new System.Drawing.Point( 12, 12 );
+            tableLayoutPanel1.Name = "tableLayoutPanel1";
+            tableLayoutPanel1.RowCount = 2;
+            tableLayoutPanel1.RowStyles.Add( new System.Windows.Forms.RowStyle( System.Windows.Forms.SizeType.Percent, 50F ) );
+            tableLayoutPanel1.RowStyles.Add( new System.Windows.Forms.RowStyle( System.Windows.Forms.SizeType.Percent, 50F ) );
+            tableLayoutPanel1.Size = new System.Drawing.Size( 371, 71 );
+            tableLayoutPanel1.TabIndex = 0;
             // 
             // label2
             // 
-            this.label2.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(3, 46);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(35, 13);
-            this.label2.TabIndex = 3;
-            this.label2.Text = "Name";
+            label2.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            label2.AutoSize = true;
+            label2.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            label2.IsDerivedStyle = true;
+            label2.Location = new System.Drawing.Point( 14, 43 );
+            label2.Name = "label2";
+            label2.Size = new System.Drawing.Size( 53, 20 );
+            label2.Style = MetroSet_UI.Enums.Style.Dark;
+            label2.StyleManager = null;
+            label2.TabIndex = 3;
+            label2.Text = "Name";
+            label2.ThemeAuthor = "Narwin";
+            label2.ThemeName = "MetroDark";
+            // 
+            // label1
+            // 
+            label1.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            label1.AutoSize = true;
+            label1.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            label1.IsDerivedStyle = true;
+            label1.Location = new System.Drawing.Point( 22, 7 );
+            label1.Name = "label1";
+            label1.Size = new System.Drawing.Size( 45, 20 );
+            label1.Style = MetroSet_UI.Enums.Style.Dark;
+            label1.StyleManager = null;
+            label1.TabIndex = 3;
+            label1.Text = "Type";
+            label1.ThemeAuthor = "Narwin";
+            label1.ThemeName = "MetroDark";
+            // 
+            // comboBox1
+            // 
+            comboBox1.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            comboBox1.BackColor = System.Drawing.Color.FromArgb(   20  ,   20  ,   20   );
+            comboBox1.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            comboBox1.ForeColor = System.Drawing.Color.Silver;
+            comboBox1.FormattingEnabled = true;
+            comboBox1.Items.AddRange( new object[] { "Diffuse Map", "Normal Map", "Specular Map", "Reflection Map", "Highlight Map", "Glow Map", "Night Map", "Detail Map", "Shadow Map" } );
+            comboBox1.Location = new System.Drawing.Point( 73, 3 );
+            comboBox1.Name = "comboBox1";
+            comboBox1.Size = new System.Drawing.Size( 295, 34 );
+            comboBox1.TabIndex = 4;
             // 
             // textBox1
             // 
-            this.textBox1.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.textBox1.Location = new System.Drawing.Point(44, 43);
-            this.textBox1.Name = "textBox1";
-            this.textBox1.Size = new System.Drawing.Size(169, 20);
-            this.textBox1.TabIndex = 5;
+            textBox1.Anchor =   System.Windows.Forms.AnchorStyles.Left  |  System.Windows.Forms.AnchorStyles.Right  ;
+            textBox1.AutoCompleteCustomSource = null;
+            textBox1.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.None;
+            textBox1.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.None;
+            textBox1.BorderColor = System.Drawing.Color.FromArgb(   110  ,   110  ,   110   );
+            textBox1.DisabledBackColor = System.Drawing.Color.FromArgb(   80  ,   80  ,   80   );
+            textBox1.DisabledBorderColor = System.Drawing.Color.FromArgb(   109  ,   109  ,   109   );
+            textBox1.DisabledForeColor = System.Drawing.Color.FromArgb(   109  ,   109  ,   109   );
+            textBox1.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            textBox1.HoverColor = System.Drawing.Color.FromArgb(   65  ,   177  ,   225   );
+            textBox1.Image = null;
+            textBox1.IsDerivedStyle = true;
+            textBox1.Lines = null;
+            textBox1.Location = new System.Drawing.Point( 73, 39 );
+            textBox1.MaxLength = 32767;
+            textBox1.Multiline = false;
+            textBox1.Name = "textBox1";
+            textBox1.ReadOnly = false;
+            textBox1.Size = new System.Drawing.Size( 295, 28 );
+            textBox1.Style = MetroSet_UI.Enums.Style.Dark;
+            textBox1.StyleManager = null;
+            textBox1.TabIndex = 5;
+            textBox1.TextAlign = System.Windows.Forms.HorizontalAlignment.Left;
+            textBox1.ThemeAuthor = "Narwin";
+            textBox1.ThemeName = "MetroDark";
+            textBox1.UseSystemPasswordChar = false;
+            textBox1.WatermarkText = "";
+            // 
+            // CancelButton
+            // 
+            CancelButton.Anchor = System.Windows.Forms.AnchorStyles.None;
+            CancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            CancelButton.ForeColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            CancelButton.Location = new System.Drawing.Point( 153, 104 );
+            CancelButton.Margin = new System.Windows.Forms.Padding( 10 );
+            CancelButton.Name = "CancelButton";
+            CancelButton.Size = new System.Drawing.Size( 97, 35 );
+            CancelButton.TabIndex = 1;
+            CancelButton.Text = "Cancel";
+            CancelButton.UseVisualStyleBackColor = true;
+            // 
+            // OKButton
+            // 
+            OKButton.Anchor = System.Windows.Forms.AnchorStyles.None;
+            OKButton.DialogResult = System.Windows.Forms.DialogResult.OK;
+            OKButton.ForeColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            OKButton.Location = new System.Drawing.Point( 270, 104 );
+            OKButton.Margin = new System.Windows.Forms.Padding( 10 );
+            OKButton.Name = "OKButton";
+            OKButton.Size = new System.Drawing.Size( 110, 35 );
+            OKButton.TabIndex = 2;
+            OKButton.Text = "OK";
+            OKButton.UseVisualStyleBackColor = true;
+            OKButton.Click += OKButton_Click;
             // 
             // CreateTextureMapDialog
             // 
-            this.AcceptButton = this.OKButton;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(243, 125);
-            this.Controls.Add(this.OKButton);
-            this.Controls.Add(this.CancelButton);
-            this.Controls.Add(this.tableLayoutPanel1);
-            this.MaximizeBox = false;
-            this.Name = "CreateTextureMapDialog";
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "CreateTextureMapDialog";
-            this.tableLayoutPanel1.ResumeLayout(false);
-            this.tableLayoutPanel1.PerformLayout();
-            this.ResumeLayout(false);
-
+            AcceptButton = OKButton;
+            AutoScaleDimensions = new System.Drawing.SizeF( 120F, 120F );
+            
+            BackColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            BackgroundColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            ClientSize = new System.Drawing.Size( 395, 151 );
+            Controls.Add( OKButton );
+            Controls.Add( CancelButton );
+            Controls.Add( tableLayoutPanel1 );
+            DropShadowEffect = false;
+            FormBorderStyle = System.Windows.Forms.FormBorderStyle.Sizable;
+            HeaderHeight = -40;
+            Name = "CreateTextureMapDialog";
+            Opacity = 0.99D;
+            Padding = new System.Windows.Forms.Padding( 2, 0, 2, 2 );
+            ShowHeader = true;
+            ShowLeftRect = false;
+            SizeGripStyle = System.Windows.Forms.SizeGripStyle.Show;
+            StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            Style = MetroSet_UI.Enums.Style.Dark;
+            Text = "CREATETEXTUREMAPDIALOG";
+            ThemeName = "MetroDark";
+            tableLayoutPanel1.ResumeLayout( false );
+            tableLayoutPanel1.PerformLayout();
+            ResumeLayout( false );
         }
 
         #endregion
@@ -153,9 +195,9 @@
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private new System.Windows.Forms.Button CancelButton;
         private System.Windows.Forms.Button OKButton;
-        private System.Windows.Forms.Label label1;
+        private MetroSetLabel label1;
         private System.Windows.Forms.ComboBox comboBox1;
-        private System.Windows.Forms.Label label2;
-        private System.Windows.Forms.TextBox textBox1;
+        private MetroSetLabel label2;
+        private MetroSetTextBox textBox1;
     }
 }

--- a/GFDStudio/GUI/Forms/CreateTextureMapDialog.cs
+++ b/GFDStudio/GUI/Forms/CreateTextureMapDialog.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Windows.Forms;
+using MetroSet_UI.Forms;
 
 namespace GFDStudio.GUI.Forms
 {
-    public partial class CreateTextureMapDialog : Form
+    public partial class CreateTextureMapDialog : MetroSetForm
     {
         public ResultValue Result { get; private set; }
 

--- a/GFDStudio/GUI/Forms/CreateTextureMapDialog.resx
+++ b/GFDStudio/GUI/Forms/CreateTextureMapDialog.resx
@@ -1,24 +1,24 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
+  <!--
     Microsoft ResX Schema 
-    
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
     <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
     <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
     <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing"">Blue</data>
     <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
         <value>[base64 mime encoded serialized .NET Framework object]</value>
     </data>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
     
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/GFDStudio/GUI/Forms/MainForm.Designer.cs
+++ b/GFDStudio/GUI/Forms/MainForm.Designer.cs
@@ -1,8 +1,13 @@
-﻿using GFDStudio.GUI.DataViewNodes;
+﻿using DarkUI.Controls;
+using DarkUI.Forms;
+using GFDStudio.GUI.DataViewNodes;
+using MetroSet_UI.Child;
+using MetroSet_UI.Controls;
+using MetroSet_UI.Forms;
 
 namespace GFDStudio.GUI.Forms
 {
-    partial class MainForm
+    partial class MainForm : MetroSetForm
     {
         /// <summary>
         /// Required designer variable.
@@ -30,408 +35,635 @@ namespace GFDStudio.GUI.Forms
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
-            this.mMainMenuStrip = new System.Windows.Forms.MenuStrip();
-            this.mFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.newToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.modelToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.mOpenToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.saveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.saveAsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.animationToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.loadExternalToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.makeRelativeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.rescaleAnimationPacksInDirectoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.convertAnimationsToP5InDirectoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.convertMaterialInDirectoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.copyP5SplitGAPToMultipleModelsInDirectoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.MassExportTexturesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.MassReplaceTexturesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.optionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.retainTexNameToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.thereIsNoHelpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.perishToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.mPropertyGrid = new System.Windows.Forms.PropertyGrid();
-            this.mContentPanel = new System.Windows.Forms.Panel();
-            this.tabControl1 = new System.Windows.Forms.TabControl();
-            this.tabPage1 = new System.Windows.Forms.TabPage();
-            this.mModelEditorTreeView = new GFDStudio.GUI.DataViewNodes.DataTreeView();
-            this.tabPage2 = new System.Windows.Forms.TabPage();
-            this.mAnimationListTreeView = new GFDStudio.GUI.DataViewNodes.DataTreeView();
-            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.mAnimationStopButton = new System.Windows.Forms.Button();
-            this.mAnimationPlaybackButton = new System.Windows.Forms.Button();
-            this.mAnimationTrackBar = new System.Windows.Forms.TrackBar();
-            this.mMainMenuStrip.SuspendLayout();
-            this.tabControl1.SuspendLayout();
-            this.tabPage1.SuspendLayout();
-            this.tabPage2.SuspendLayout();
-            this.tableLayoutPanel1.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.mAnimationTrackBar)).BeginInit();
-            this.SuspendLayout();
+            components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager( typeof( MainForm ) );
+            mMainMenuStrip = new System.Windows.Forms.MenuStrip();
+            mFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            newToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            modelToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            mOpenToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            saveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            saveAsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            animationToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            loadExternalToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            toolsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            makeRelativeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            rescaleAnimationPacksInDirectoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            convertAnimationsToP5InDirectoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            convertMaterialInDirectoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            copyP5SplitGAPToMultipleModelsInDirectoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            MassExportTexturesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            MassReplaceTexturesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            optionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            retainTexNameToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            thereIsNoHelpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            perishToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            mContentPanel = new System.Windows.Forms.Panel();
+            tabControl1 = new MetroSetTabControl();
+            tabPage1 = new MetroSetSetTabPage();
+            mModelEditorTreeView = new DataTreeView();
+            tabPage2 = new MetroSetSetTabPage();
+            mAnimationListTreeView = new DataTreeView();
+            tableLayoutPanel_AnimationControls = new System.Windows.Forms.TableLayoutPanel();
+            mAnimationTrackBar = new System.Windows.Forms.TrackBar();
+            mAnimationPlaybackButton = new MetroSetButton();
+            mAnimationStopButton = new MetroSetButton();
+            splitContainer_Main = new System.Windows.Forms.SplitContainer();
+            splitContainer_LeftSide = new System.Windows.Forms.SplitContainer();
+            splitContainer_RightSide = new System.Windows.Forms.SplitContainer();
+            panel_PropertyGridContainer = new System.Windows.Forms.Panel();
+            mPropertyGrid = new System.Windows.Forms.PropertyGrid();
+            mMainMenuStrip.SuspendLayout();
+            tabControl1.SuspendLayout();
+            tabPage1.SuspendLayout();
+            tabPage2.SuspendLayout();
+            tableLayoutPanel_AnimationControls.SuspendLayout();
+            ( (System.ComponentModel.ISupportInitialize) mAnimationTrackBar  ).BeginInit();
+            ( (System.ComponentModel.ISupportInitialize) splitContainer_Main  ).BeginInit();
+            splitContainer_Main.Panel1.SuspendLayout();
+            splitContainer_Main.Panel2.SuspendLayout();
+            splitContainer_Main.SuspendLayout();
+            ( (System.ComponentModel.ISupportInitialize) splitContainer_LeftSide  ).BeginInit();
+            splitContainer_LeftSide.Panel1.SuspendLayout();
+            splitContainer_LeftSide.Panel2.SuspendLayout();
+            splitContainer_LeftSide.SuspendLayout();
+            ( (System.ComponentModel.ISupportInitialize) splitContainer_RightSide  ).BeginInit();
+            splitContainer_RightSide.Panel1.SuspendLayout();
+            splitContainer_RightSide.Panel2.SuspendLayout();
+            splitContainer_RightSide.SuspendLayout();
+            panel_PropertyGridContainer.SuspendLayout();
+            SuspendLayout();
             // 
             // mMainMenuStrip
             // 
-            this.mMainMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.mFileToolStripMenuItem,
-            this.animationToolStripMenuItem,
-            this.toolsToolStripMenuItem,
-            this.optionsToolStripMenuItem,
-            this.helpToolStripMenuItem});
-            this.mMainMenuStrip.Location = new System.Drawing.Point(0, 0);
-            this.mMainMenuStrip.Name = "mMainMenuStrip";
-            this.mMainMenuStrip.Padding = new System.Windows.Forms.Padding(7, 2, 0, 2);
-            this.mMainMenuStrip.Size = new System.Drawing.Size(1461, 24);
-            this.mMainMenuStrip.TabIndex = 0;
-            this.mMainMenuStrip.Text = "menuStrip1";
+            mMainMenuStrip.BackColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            mMainMenuStrip.ForeColor = System.Drawing.Color.FromArgb(   220  ,   220  ,   220   );
+            mMainMenuStrip.ImageScalingSize = new System.Drawing.Size( 20, 20 );
+            mMainMenuStrip.Items.AddRange( new System.Windows.Forms.ToolStripItem[] { mFileToolStripMenuItem, animationToolStripMenuItem, toolsToolStripMenuItem, optionsToolStripMenuItem, helpToolStripMenuItem } );
+            mMainMenuStrip.Location = new System.Drawing.Point( 2, 0 );
+            mMainMenuStrip.Name = "mMainMenuStrip";
+            mMainMenuStrip.Padding = new System.Windows.Forms.Padding( 8, 3, 0, 3 );
+            mMainMenuStrip.Size = new System.Drawing.Size( 878, 30 );
+            mMainMenuStrip.TabIndex = 0;
+            mMainMenuStrip.Text = "menuStrip1";
             // 
             // mFileToolStripMenuItem
             // 
-            this.mFileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.newToolStripMenuItem,
-            this.mOpenToolStripMenuItem,
-            this.saveToolStripMenuItem,
-            this.saveAsToolStripMenuItem});
-            this.mFileToolStripMenuItem.Name = "mFileToolStripMenuItem";
-            this.mFileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
-            this.mFileToolStripMenuItem.Text = "File";
+            mFileToolStripMenuItem.AutoSize = false;
+            mFileToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            mFileToolStripMenuItem.DropDownItems.AddRange( new System.Windows.Forms.ToolStripItem[] { newToolStripMenuItem, mOpenToolStripMenuItem, saveToolStripMenuItem, saveAsToolStripMenuItem } );
+            mFileToolStripMenuItem.ForeColor = System.Drawing.Color.Silver;
+            mFileToolStripMenuItem.Name = "mFileToolStripMenuItem";
+            mFileToolStripMenuItem.Size = new System.Drawing.Size( 46, 24 );
+            mFileToolStripMenuItem.Text = "File";
             // 
             // newToolStripMenuItem
             // 
-            this.newToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.modelToolStripMenuItem});
-            this.newToolStripMenuItem.Name = "newToolStripMenuItem";
-            this.newToolStripMenuItem.Size = new System.Drawing.Size(193, 22);
-            this.newToolStripMenuItem.Text = "New";
+            newToolStripMenuItem.AutoSize = false;
+            newToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            newToolStripMenuItem.DropDownItems.AddRange( new System.Windows.Forms.ToolStripItem[] { modelToolStripMenuItem } );
+            newToolStripMenuItem.ForeColor = System.Drawing.Color.Silver;
+            newToolStripMenuItem.Name = "newToolStripMenuItem";
+            newToolStripMenuItem.Size = new System.Drawing.Size( 240, 26 );
+            newToolStripMenuItem.Text = "New";
             // 
             // modelToolStripMenuItem
             // 
-            this.modelToolStripMenuItem.Name = "modelToolStripMenuItem";
-            this.modelToolStripMenuItem.Size = new System.Drawing.Size(108, 22);
-            this.modelToolStripMenuItem.Text = "Model";
-            this.modelToolStripMenuItem.Click += new System.EventHandler(this.HandleNewModelToolStripMenuItemClick);
+            modelToolStripMenuItem.AutoSize = false;
+            modelToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            modelToolStripMenuItem.ForeColor = System.Drawing.Color.Silver;
+            modelToolStripMenuItem.Name = "modelToolStripMenuItem";
+            modelToolStripMenuItem.Size = new System.Drawing.Size( 224, 26 );
+            modelToolStripMenuItem.Text = "Model";
+            modelToolStripMenuItem.Click += HandleNewModelToolStripMenuItemClick;
             // 
             // mOpenToolStripMenuItem
             // 
-            this.mOpenToolStripMenuItem.Name = "mOpenToolStripMenuItem";
-            this.mOpenToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
-            this.mOpenToolStripMenuItem.Size = new System.Drawing.Size(193, 22);
-            this.mOpenToolStripMenuItem.Text = "Open";
-            this.mOpenToolStripMenuItem.Click += new System.EventHandler(this.HandleOpenToolStripMenuItemClick);
+            mOpenToolStripMenuItem.AutoSize = false;
+            mOpenToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            mOpenToolStripMenuItem.ForeColor = System.Drawing.Color.Silver;
+            mOpenToolStripMenuItem.Name = "mOpenToolStripMenuItem";
+            mOpenToolStripMenuItem.ShortcutKeys =   System.Windows.Forms.Keys.Control  |  System.Windows.Forms.Keys.O  ;
+            mOpenToolStripMenuItem.Size = new System.Drawing.Size( 240, 26 );
+            mOpenToolStripMenuItem.Text = "Open";
+            mOpenToolStripMenuItem.Click += HandleOpenToolStripMenuItemClick;
             // 
             // saveToolStripMenuItem
             // 
-            this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
-            this.saveToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-            this.saveToolStripMenuItem.Size = new System.Drawing.Size(193, 22);
-            this.saveToolStripMenuItem.Text = "Save";
-            this.saveToolStripMenuItem.Click += new System.EventHandler(this.HandleSaveToolStripMenuItemClick);
+            saveToolStripMenuItem.AutoSize = false;
+            saveToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            saveToolStripMenuItem.ForeColor = System.Drawing.Color.Silver;
+            saveToolStripMenuItem.Name = "saveToolStripMenuItem";
+            saveToolStripMenuItem.ShortcutKeys =   System.Windows.Forms.Keys.Control  |  System.Windows.Forms.Keys.S  ;
+            saveToolStripMenuItem.Size = new System.Drawing.Size( 240, 26 );
+            saveToolStripMenuItem.Text = "Save";
+            saveToolStripMenuItem.Click += HandleSaveToolStripMenuItemClick;
             // 
             // saveAsToolStripMenuItem
             // 
-            this.saveAsToolStripMenuItem.Name = "saveAsToolStripMenuItem";
-            this.saveAsToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
-            | System.Windows.Forms.Keys.S)));
-            this.saveAsToolStripMenuItem.Size = new System.Drawing.Size(193, 22);
-            this.saveAsToolStripMenuItem.Text = "Save as...";
-            this.saveAsToolStripMenuItem.Click += new System.EventHandler(this.HandleSaveAsToolStripMenuItemClick);
+            saveAsToolStripMenuItem.AutoSize = false;
+            saveAsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            saveAsToolStripMenuItem.ForeColor = System.Drawing.Color.Silver;
+            saveAsToolStripMenuItem.Name = "saveAsToolStripMenuItem";
+            saveAsToolStripMenuItem.ShortcutKeys =    System.Windows.Forms.Keys.Control  |  System.Windows.Forms.Keys.Shift   |  System.Windows.Forms.Keys.S  ;
+            saveAsToolStripMenuItem.Size = new System.Drawing.Size( 240, 26 );
+            saveAsToolStripMenuItem.Text = "Save as...";
+            saveAsToolStripMenuItem.Click += HandleSaveAsToolStripMenuItemClick;
             // 
             // animationToolStripMenuItem
             // 
-            this.animationToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.loadExternalToolStripMenuItem});
-            this.animationToolStripMenuItem.Name = "animationToolStripMenuItem";
-            this.animationToolStripMenuItem.Size = new System.Drawing.Size(75, 20);
-            this.animationToolStripMenuItem.Text = "Animation";
+            animationToolStripMenuItem.AutoSize = false;
+            animationToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            animationToolStripMenuItem.DropDownItems.AddRange( new System.Windows.Forms.ToolStripItem[] { loadExternalToolStripMenuItem } );
+            animationToolStripMenuItem.ForeColor = System.Drawing.Color.Silver;
+            animationToolStripMenuItem.Name = "animationToolStripMenuItem";
+            animationToolStripMenuItem.Size = new System.Drawing.Size( 92, 24 );
+            animationToolStripMenuItem.Text = "Animation";
             // 
             // loadExternalToolStripMenuItem
             // 
-            this.loadExternalToolStripMenuItem.Name = "loadExternalToolStripMenuItem";
-            this.loadExternalToolStripMenuItem.Size = new System.Drawing.Size(100, 22);
-            this.loadExternalToolStripMenuItem.Text = "Load";
-            this.loadExternalToolStripMenuItem.Click += new System.EventHandler(this.HandleAnimationLoadExternalToolStripMenuItemClick);
+            loadExternalToolStripMenuItem.AutoSize = false;
+            loadExternalToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            loadExternalToolStripMenuItem.ForeColor = System.Drawing.Color.Silver;
+            loadExternalToolStripMenuItem.Name = "loadExternalToolStripMenuItem";
+            loadExternalToolStripMenuItem.Size = new System.Drawing.Size( 224, 26 );
+            loadExternalToolStripMenuItem.Text = "Load";
+            loadExternalToolStripMenuItem.Click += HandleAnimationLoadExternalToolStripMenuItemClick;
             // 
             // toolsToolStripMenuItem
             // 
-            this.toolsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.makeRelativeToolStripMenuItem,
-            this.rescaleAnimationPacksInDirectoryToolStripMenuItem,
-            this.convertAnimationsToP5InDirectoryToolStripMenuItem,
-            this.convertMaterialInDirectoryToolStripMenuItem,
-            this.copyP5SplitGAPToMultipleModelsInDirectoryToolStripMenuItem,
-            this.MassExportTexturesToolStripMenuItem,
-            this.MassReplaceTexturesToolStripMenuItem} );
-            this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
-            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(46, 20);
-            this.toolsToolStripMenuItem.Text = "Tools";
+            toolsToolStripMenuItem.AutoSize = false;
+            toolsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            toolsToolStripMenuItem.DropDownItems.AddRange( new System.Windows.Forms.ToolStripItem[] { makeRelativeToolStripMenuItem, rescaleAnimationPacksInDirectoryToolStripMenuItem, convertAnimationsToP5InDirectoryToolStripMenuItem, convertMaterialInDirectoryToolStripMenuItem, copyP5SplitGAPToMultipleModelsInDirectoryToolStripMenuItem, MassExportTexturesToolStripMenuItem, MassReplaceTexturesToolStripMenuItem } );
+            toolsToolStripMenuItem.ForeColor = System.Drawing.Color.Silver;
+            toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
+            toolsToolStripMenuItem.Size = new System.Drawing.Size( 58, 24 );
+            toolsToolStripMenuItem.Text = "Tools";
             // 
             // makeRelativeToolStripMenuItem
             // 
-            this.makeRelativeToolStripMenuItem.Name = "makeRelativeToolStripMenuItem";
-            this.makeRelativeToolStripMenuItem.Size = new System.Drawing.Size(336, 22);
-            this.makeRelativeToolStripMenuItem.Text = "Retarget animation packs in directory";
-            this.makeRelativeToolStripMenuItem.Click += new System.EventHandler(this.HandleRetargetAnimationsToolStripMenuItemClick);
+            makeRelativeToolStripMenuItem.AutoSize = false;
+            makeRelativeToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            makeRelativeToolStripMenuItem.ForeColor = System.Drawing.Color.Silver;
+            makeRelativeToolStripMenuItem.Name = "makeRelativeToolStripMenuItem";
+            makeRelativeToolStripMenuItem.Size = new System.Drawing.Size( 421, 26 );
+            makeRelativeToolStripMenuItem.Text = "Retarget animation packs in directory";
+            makeRelativeToolStripMenuItem.Click += HandleRetargetAnimationsToolStripMenuItemClick;
             // 
             // rescaleAnimationPacksInDirectoryToolStripMenuItem
             // 
-            this.rescaleAnimationPacksInDirectoryToolStripMenuItem.Name = "rescaleAnimationPacksInDirectoryToolStripMenuItem";
-            this.rescaleAnimationPacksInDirectoryToolStripMenuItem.Size = new System.Drawing.Size(336, 22);
-            this.rescaleAnimationPacksInDirectoryToolStripMenuItem.Text = "Rescale/Reposition animation packs in directory";
-            this.rescaleAnimationPacksInDirectoryToolStripMenuItem.Click += new System.EventHandler(this.HandleRescaleAnimationsToolStripMenuItemClick);
+            rescaleAnimationPacksInDirectoryToolStripMenuItem.AutoSize = false;
+            rescaleAnimationPacksInDirectoryToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            rescaleAnimationPacksInDirectoryToolStripMenuItem.ForeColor = System.Drawing.Color.Silver;
+            rescaleAnimationPacksInDirectoryToolStripMenuItem.Name = "rescaleAnimationPacksInDirectoryToolStripMenuItem";
+            rescaleAnimationPacksInDirectoryToolStripMenuItem.Size = new System.Drawing.Size( 421, 26 );
+            rescaleAnimationPacksInDirectoryToolStripMenuItem.Text = "Rescale/Reposition animation packs in directory";
+            rescaleAnimationPacksInDirectoryToolStripMenuItem.Click += HandleRescaleAnimationsToolStripMenuItemClick;
             // 
             // convertAnimationsToP5InDirectoryToolStripMenuItem
             // 
-            this.convertAnimationsToP5InDirectoryToolStripMenuItem.Name = "convertAnimationsToP5InDirectoryToolStripMenuItem";
-            this.convertAnimationsToP5InDirectoryToolStripMenuItem.Size = new System.Drawing.Size(336, 22);
-            this.convertAnimationsToP5InDirectoryToolStripMenuItem.Text = "Convert P5R animations to P5 in directory";
-            this.convertAnimationsToP5InDirectoryToolStripMenuItem.Click += new System.EventHandler(this.HandleConvertAnimationsToolStripMenuItemClick);
+            convertAnimationsToP5InDirectoryToolStripMenuItem.AutoSize = false;
+            convertAnimationsToP5InDirectoryToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            convertAnimationsToP5InDirectoryToolStripMenuItem.ForeColor = System.Drawing.Color.Silver;
+            convertAnimationsToP5InDirectoryToolStripMenuItem.Name = "convertAnimationsToP5InDirectoryToolStripMenuItem";
+            convertAnimationsToP5InDirectoryToolStripMenuItem.Size = new System.Drawing.Size( 421, 26 );
+            convertAnimationsToP5InDirectoryToolStripMenuItem.Text = "Convert P5R animations to P5 in directory";
+            convertAnimationsToP5InDirectoryToolStripMenuItem.Click += HandleConvertAnimationsToolStripMenuItemClick;
             // 
             // convertMaterialInDirectoryToolStripMenuItem
             // 
-            this.convertMaterialInDirectoryToolStripMenuItem.Name = "convertMaterialInDirectoryToolStripMenuItem";
-            this.convertMaterialInDirectoryToolStripMenuItem.Size = new System.Drawing.Size(336, 22);
-            this.convertMaterialInDirectoryToolStripMenuItem.Text = "Convert model materials in directory";
-            this.convertMaterialInDirectoryToolStripMenuItem.Click += new System.EventHandler(this.HandleConvertMaterialsToolStripMenuItemClick);
+            convertMaterialInDirectoryToolStripMenuItem.AutoSize = false;
+            convertMaterialInDirectoryToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            convertMaterialInDirectoryToolStripMenuItem.ForeColor = System.Drawing.Color.Silver;
+            convertMaterialInDirectoryToolStripMenuItem.Name = "convertMaterialInDirectoryToolStripMenuItem";
+            convertMaterialInDirectoryToolStripMenuItem.Size = new System.Drawing.Size( 421, 26 );
+            convertMaterialInDirectoryToolStripMenuItem.Text = "Convert model materials in directory";
+            convertMaterialInDirectoryToolStripMenuItem.Click += HandleConvertMaterialsToolStripMenuItemClick;
             // 
             // copyP5SplitGAPToMultipleModelsInDirectoryToolStripMenuItem
             // 
-            this.copyP5SplitGAPToMultipleModelsInDirectoryToolStripMenuItem.Name = "copyP5SplitGAPToMultipleModelsInDirectoryToolStripMenuItem";
-            this.copyP5SplitGAPToMultipleModelsInDirectoryToolStripMenuItem.Size = new System.Drawing.Size(336, 22);
-            this.copyP5SplitGAPToMultipleModelsInDirectoryToolStripMenuItem.Text = "Copy P5 Split GAP to multiple models in directory";
-            this.copyP5SplitGAPToMultipleModelsInDirectoryToolStripMenuItem.Click += new System.EventHandler(this.copyP5SplitGAPToMultipleModelsInDirectoryToolStripMenuItem_Click);
+            copyP5SplitGAPToMultipleModelsInDirectoryToolStripMenuItem.AutoSize = false;
+            copyP5SplitGAPToMultipleModelsInDirectoryToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            copyP5SplitGAPToMultipleModelsInDirectoryToolStripMenuItem.ForeColor = System.Drawing.Color.Silver;
+            copyP5SplitGAPToMultipleModelsInDirectoryToolStripMenuItem.Name = "copyP5SplitGAPToMultipleModelsInDirectoryToolStripMenuItem";
+            copyP5SplitGAPToMultipleModelsInDirectoryToolStripMenuItem.Size = new System.Drawing.Size( 421, 26 );
+            copyP5SplitGAPToMultipleModelsInDirectoryToolStripMenuItem.Text = "Copy P5 Split GAP to multiple models in directory";
+            copyP5SplitGAPToMultipleModelsInDirectoryToolStripMenuItem.Click += copyP5SplitGAPToMultipleModelsInDirectoryToolStripMenuItem_Click;
             // 
             // MassExportTexturesToolStripMenuItem
             // 
-            this.MassExportTexturesToolStripMenuItem.Name = "MassExportTexturesToolStripMenuItem";
-            this.MassExportTexturesToolStripMenuItem.Size = new System.Drawing.Size(336, 22);
-            this.MassExportTexturesToolStripMenuItem.Text = "Mass Export Textures from Models";
-            this.MassExportTexturesToolStripMenuItem.Click += new System.EventHandler(this.MassExportTexturesToolStripMenuItem_Click );
+            MassExportTexturesToolStripMenuItem.AutoSize = false;
+            MassExportTexturesToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            MassExportTexturesToolStripMenuItem.ForeColor = System.Drawing.Color.Silver;
+            MassExportTexturesToolStripMenuItem.Name = "MassExportTexturesToolStripMenuItem";
+            MassExportTexturesToolStripMenuItem.Size = new System.Drawing.Size( 421, 26 );
+            MassExportTexturesToolStripMenuItem.Text = "Mass Export Textures from Models";
+            MassExportTexturesToolStripMenuItem.Click += MassExportTexturesToolStripMenuItem_Click;
             // 
             // MassReplaceTexturesToolStripMenuItem
             // 
-            this.MassReplaceTexturesToolStripMenuItem.Name = "MassReplaceTexturesToolStripMenuItem";
-            this.MassReplaceTexturesToolStripMenuItem.Size = new System.Drawing.Size(336, 22);
-            this.MassReplaceTexturesToolStripMenuItem.Text = "Mass Replace Textures in Models";
-            this.MassReplaceTexturesToolStripMenuItem.Click += new System.EventHandler(this.MassReplaceTexturesToolStripMenuItem_Click );
+            MassReplaceTexturesToolStripMenuItem.AutoSize = false;
+            MassReplaceTexturesToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            MassReplaceTexturesToolStripMenuItem.ForeColor = System.Drawing.Color.Silver;
+            MassReplaceTexturesToolStripMenuItem.Name = "MassReplaceTexturesToolStripMenuItem";
+            MassReplaceTexturesToolStripMenuItem.Size = new System.Drawing.Size( 421, 26 );
+            MassReplaceTexturesToolStripMenuItem.Text = "Mass Replace Textures in Models";
+            MassReplaceTexturesToolStripMenuItem.Click += MassReplaceTexturesToolStripMenuItem_Click;
             // 
             // optionsToolStripMenuItem
             // 
-            this.optionsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.retainTexNameToolStripMenuItem});
-            this.optionsToolStripMenuItem.Name = "optionsToolStripMenuItem";
-            this.optionsToolStripMenuItem.Size = new System.Drawing.Size(61, 20);
-            this.optionsToolStripMenuItem.Text = "Options";
+            optionsToolStripMenuItem.AutoSize = false;
+            optionsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            optionsToolStripMenuItem.DropDownItems.AddRange( new System.Windows.Forms.ToolStripItem[] { retainTexNameToolStripMenuItem } );
+            optionsToolStripMenuItem.ForeColor = System.Drawing.Color.Silver;
+            optionsToolStripMenuItem.Name = "optionsToolStripMenuItem";
+            optionsToolStripMenuItem.Size = new System.Drawing.Size( 75, 24 );
+            optionsToolStripMenuItem.Text = "Options";
             // 
             // retainTexNameToolStripMenuItem
             // 
-            this.retainTexNameToolStripMenuItem.Checked = true;
-            this.retainTexNameToolStripMenuItem.CheckOnClick = true;
-            this.retainTexNameToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.retainTexNameToolStripMenuItem.Name = "retainTexNameToolStripMenuItem";
-            this.retainTexNameToolStripMenuItem.Size = new System.Drawing.Size(366, 22);
-            this.retainTexNameToolStripMenuItem.Text = "Retain original material\'s texture names when replacing";
+            retainTexNameToolStripMenuItem.AutoSize = false;
+            retainTexNameToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(   20  ,   20  ,   20   );
+            retainTexNameToolStripMenuItem.Checked = true;
+            retainTexNameToolStripMenuItem.CheckOnClick = true;
+            retainTexNameToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            retainTexNameToolStripMenuItem.ForeColor = System.Drawing.Color.Silver;
+            retainTexNameToolStripMenuItem.Name = "retainTexNameToolStripMenuItem";
+            retainTexNameToolStripMenuItem.Size = new System.Drawing.Size( 459, 26 );
+            retainTexNameToolStripMenuItem.Text = "Retain original material's texture names when replacing";
             // 
             // helpToolStripMenuItem
             // 
-            this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.thereIsNoHelpToolStripMenuItem,
-            this.perishToolStripMenuItem});
-            this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
-            this.helpToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
-            this.helpToolStripMenuItem.Text = "Help";
+            helpToolStripMenuItem.AutoSize = false;
+            helpToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            helpToolStripMenuItem.DropDownItems.AddRange( new System.Windows.Forms.ToolStripItem[] { thereIsNoHelpToolStripMenuItem, perishToolStripMenuItem } );
+            helpToolStripMenuItem.ForeColor = System.Drawing.Color.Silver;
+            helpToolStripMenuItem.Name = "helpToolStripMenuItem";
+            helpToolStripMenuItem.Size = new System.Drawing.Size( 55, 24 );
+            helpToolStripMenuItem.Text = "Help";
             // 
             // thereIsNoHelpToolStripMenuItem
             // 
-            this.thereIsNoHelpToolStripMenuItem.Enabled = false;
-            this.thereIsNoHelpToolStripMenuItem.Name = "thereIsNoHelpToolStripMenuItem";
-            this.thereIsNoHelpToolStripMenuItem.Size = new System.Drawing.Size(160, 22);
-            this.thereIsNoHelpToolStripMenuItem.Text = "There is no help.";
+            thereIsNoHelpToolStripMenuItem.AutoSize = false;
+            thereIsNoHelpToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            thereIsNoHelpToolStripMenuItem.Enabled = false;
+            thereIsNoHelpToolStripMenuItem.ForeColor = System.Drawing.Color.Silver;
+            thereIsNoHelpToolStripMenuItem.Name = "thereIsNoHelpToolStripMenuItem";
+            thereIsNoHelpToolStripMenuItem.Size = new System.Drawing.Size( 200, 26 );
+            thereIsNoHelpToolStripMenuItem.Text = "There is no help.";
             // 
             // perishToolStripMenuItem
             // 
-            this.perishToolStripMenuItem.Enabled = false;
-            this.perishToolStripMenuItem.Name = "perishToolStripMenuItem";
-            this.perishToolStripMenuItem.Size = new System.Drawing.Size(160, 22);
-            this.perishToolStripMenuItem.Text = "Perish.";
-            // 
-            // mPropertyGrid
-            // 
-            this.mPropertyGrid.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.mPropertyGrid.LineColor = System.Drawing.SystemColors.ControlDark;
-            this.mPropertyGrid.Location = new System.Drawing.Point(867, 513);
-            this.mPropertyGrid.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.mPropertyGrid.Name = "mPropertyGrid";
-            this.mPropertyGrid.PropertySort = System.Windows.Forms.PropertySort.NoSort;
-            this.mPropertyGrid.Size = new System.Drawing.Size(580, 337);
-            this.mPropertyGrid.TabIndex = 2;
+            perishToolStripMenuItem.AutoSize = false;
+            perishToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            perishToolStripMenuItem.Enabled = false;
+            perishToolStripMenuItem.ForeColor = System.Drawing.Color.Silver;
+            perishToolStripMenuItem.Name = "perishToolStripMenuItem";
+            perishToolStripMenuItem.Size = new System.Drawing.Size( 200, 26 );
+            perishToolStripMenuItem.Text = "Perish.";
             // 
             // mContentPanel
             // 
-            this.mContentPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.mContentPanel.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.mContentPanel.Location = new System.Drawing.Point(14, 32);
-            this.mContentPanel.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.mContentPanel.Name = "mContentPanel";
-            this.mContentPanel.Size = new System.Drawing.Size(846, 770);
-            this.mContentPanel.TabIndex = 3;
+            mContentPanel.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            mContentPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            mContentPanel.Location = new System.Drawing.Point( 0, 0 );
+            mContentPanel.Margin = new System.Windows.Forms.Padding( 5, 4, 5, 4 );
+            mContentPanel.Name = "mContentPanel";
+            mContentPanel.Size = new System.Drawing.Size( 451, 492 );
+            mContentPanel.TabIndex = 3;
             // 
             // tabControl1
             // 
-            this.tabControl1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.tabControl1.Controls.Add(this.tabPage1);
-            this.tabControl1.Controls.Add(this.tabPage2);
-            this.tabControl1.Location = new System.Drawing.Point(867, 32);
-            this.tabControl1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.tabControl1.Name = "tabControl1";
-            this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(580, 474);
-            this.tabControl1.TabIndex = 4;
+            tabControl1.AnimateEasingType = MetroSet_UI.Enums.EasingType.CubeOut;
+            tabControl1.AnimateTime = 200;
+            tabControl1.BackgroundColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            tabControl1.Controls.Add( tabPage1 );
+            tabControl1.Controls.Add( tabPage2 );
+            tabControl1.Dock = System.Windows.Forms.DockStyle.Fill;
+            tabControl1.ForeColor = System.Drawing.Color.Silver;
+            tabControl1.IsDerivedStyle = true;
+            tabControl1.ItemSize = new System.Drawing.Size( 100, 38 );
+            tabControl1.Location = new System.Drawing.Point( 0, 0 );
+            tabControl1.Name = "tabControl1";
+            tabControl1.SelectedIndex = 0;
+            tabControl1.SelectedTextColor = System.Drawing.Color.White;
+            tabControl1.Size = new System.Drawing.Size( 423, 225 );
+            tabControl1.SizeMode = System.Windows.Forms.TabSizeMode.Fixed;
+            tabControl1.Speed = 100;
+            tabControl1.Style = MetroSet_UI.Enums.Style.Dark;
+            tabControl1.StyleManager = null;
+            tabControl1.TabIndex = 4;
+            tabControl1.TabStyle = MetroSet_UI.Enums.TabStyle.Style2;
+            tabControl1.ThemeAuthor = "Narwin";
+            tabControl1.ThemeName = "MetroDark";
+            tabControl1.UnselectedTextColor = System.Drawing.Color.Gray;
+            tabControl1.UseAnimation = false;
             // 
             // tabPage1
             // 
-            this.tabPage1.Controls.Add(this.mModelEditorTreeView);
-            this.tabPage1.Location = new System.Drawing.Point(4, 24);
-            this.tabPage1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.tabPage1.Name = "tabPage1";
-            this.tabPage1.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.tabPage1.Size = new System.Drawing.Size(572, 446);
-            this.tabPage1.TabIndex = 0;
-            this.tabPage1.Text = "Model Editor";
-            this.tabPage1.UseVisualStyleBackColor = true;
+            tabPage1.BaseColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            tabPage1.Controls.Add( mModelEditorTreeView );
+            tabPage1.Dock = System.Windows.Forms.DockStyle.Fill;
+            tabPage1.Font = null;
+            tabPage1.ForeColor = System.Drawing.Color.Silver;
+            tabPage1.ImageIndex = 0;
+            tabPage1.ImageKey = null;
+            tabPage1.IsDerivedStyle = true;
+            tabPage1.Location = new System.Drawing.Point( 4, 42 );
+            tabPage1.Margin = new System.Windows.Forms.Padding( 5, 4, 5, 4 );
+            tabPage1.Name = "tabPage1";
+            tabPage1.Padding = new System.Windows.Forms.Padding( 5, 4, 5, 4 );
+            tabPage1.Size = new System.Drawing.Size( 415, 179 );
+            tabPage1.Style = MetroSet_UI.Enums.Style.Dark;
+            tabPage1.StyleManager = null;
+            tabPage1.TabIndex = 0;
+            tabPage1.Text = "Model Editor";
+            tabPage1.ThemeAuthor = "Narwin";
+            tabPage1.ThemeName = "MetroDark";
+            tabPage1.ToolTipText = null;
             // 
             // mModelEditorTreeView
             // 
-            this.mModelEditorTreeView.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.mModelEditorTreeView.ImageIndex = 0;
-            this.mModelEditorTreeView.Location = new System.Drawing.Point(7, 7);
-            this.mModelEditorTreeView.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.mModelEditorTreeView.Name = "mModelEditorTreeView";
-            this.mModelEditorTreeView.SelectedImageIndex = 0;
-            this.mModelEditorTreeView.Size = new System.Drawing.Size(556, 430);
-            this.mModelEditorTreeView.TabIndex = 1;
-            this.mModelEditorTreeView.TopNode = null;
+            mModelEditorTreeView.BackColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            mModelEditorTreeView.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            mModelEditorTreeView.Dock = System.Windows.Forms.DockStyle.Fill;
+            mModelEditorTreeView.ForeColor = System.Drawing.Color.Silver;
+            mModelEditorTreeView.ImageIndex = 0;
+            mModelEditorTreeView.Location = new System.Drawing.Point( 5, 4 );
+            mModelEditorTreeView.Margin = new System.Windows.Forms.Padding( 5, 4, 5, 4 );
+            mModelEditorTreeView.Name = "mModelEditorTreeView";
+            mModelEditorTreeView.SelectedImageIndex = 0;
+            mModelEditorTreeView.Size = new System.Drawing.Size( 405, 171 );
+            mModelEditorTreeView.TabIndex = 1;
+            mModelEditorTreeView.TopNode = null;
             // 
             // tabPage2
             // 
-            this.tabPage2.Controls.Add(this.mAnimationListTreeView);
-            this.tabPage2.Location = new System.Drawing.Point(4, 24);
-            this.tabPage2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.tabPage2.Name = "tabPage2";
-            this.tabPage2.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.tabPage2.Size = new System.Drawing.Size(572, 446);
-            this.tabPage2.TabIndex = 1;
-            this.tabPage2.Text = "Animation List";
-            this.tabPage2.UseVisualStyleBackColor = true;
+            tabPage2.BaseColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            tabPage2.Controls.Add( mAnimationListTreeView );
+            tabPage2.Dock = System.Windows.Forms.DockStyle.Fill;
+            tabPage2.Font = null;
+            tabPage2.ForeColor = System.Drawing.Color.Silver;
+            tabPage2.ImageIndex = 0;
+            tabPage2.ImageKey = null;
+            tabPage2.IsDerivedStyle = true;
+            tabPage2.Location = new System.Drawing.Point( 4, 42 );
+            tabPage2.Margin = new System.Windows.Forms.Padding( 5, 4, 5, 4 );
+            tabPage2.Name = "tabPage2";
+            tabPage2.Padding = new System.Windows.Forms.Padding( 5, 4, 5, 4 );
+            tabPage2.Size = new System.Drawing.Size( 415, 179 );
+            tabPage2.Style = MetroSet_UI.Enums.Style.Dark;
+            tabPage2.StyleManager = null;
+            tabPage2.TabIndex = 1;
+            tabPage2.Text = "Animation List";
+            tabPage2.ThemeAuthor = "Narwin";
+            tabPage2.ThemeName = "MetroDark";
+            tabPage2.ToolTipText = null;
             // 
             // mAnimationListTreeView
             // 
-            this.mAnimationListTreeView.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.mAnimationListTreeView.ImageIndex = 0;
-            this.mAnimationListTreeView.Location = new System.Drawing.Point(7, 7);
-            this.mAnimationListTreeView.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.mAnimationListTreeView.Name = "mAnimationListTreeView";
-            this.mAnimationListTreeView.SelectedImageIndex = 0;
-            this.mAnimationListTreeView.Size = new System.Drawing.Size(556, 430);
-            this.mAnimationListTreeView.TabIndex = 2;
-            this.mAnimationListTreeView.TopNode = null;
+            mAnimationListTreeView.BackColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            mAnimationListTreeView.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            mAnimationListTreeView.Dock = System.Windows.Forms.DockStyle.Fill;
+            mAnimationListTreeView.ForeColor = System.Drawing.Color.Silver;
+            mAnimationListTreeView.ImageIndex = 0;
+            mAnimationListTreeView.Location = new System.Drawing.Point( 5, 4 );
+            mAnimationListTreeView.Margin = new System.Windows.Forms.Padding( 5, 4, 5, 4 );
+            mAnimationListTreeView.Name = "mAnimationListTreeView";
+            mAnimationListTreeView.SelectedImageIndex = 0;
+            mAnimationListTreeView.Size = new System.Drawing.Size( 405, 171 );
+            mAnimationListTreeView.TabIndex = 2;
+            mAnimationListTreeView.TopNode = null;
             // 
-            // tableLayoutPanel1
+            // tableLayoutPanel_AnimationControls
             // 
-            this.tableLayoutPanel1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.tableLayoutPanel1.ColumnCount = 8;
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 16.66667F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 16.66667F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 16.66667F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 16.66667F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 16.66667F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 16.66667F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 82F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 164F));
-            this.tableLayoutPanel1.Controls.Add(this.mAnimationStopButton, 7, 0);
-            this.tableLayoutPanel1.Controls.Add(this.mAnimationPlaybackButton, 6, 0);
-            this.tableLayoutPanel1.Controls.Add(this.mAnimationTrackBar, 0, 0);
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(14, 810);
-            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            this.tableLayoutPanel1.RowCount = 1;
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(846, 40);
-            this.tableLayoutPanel1.TabIndex = 0;
-            // 
-            // mAnimationStopButton
-            // 
-            this.mAnimationStopButton.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.mAnimationStopButton.Location = new System.Drawing.Point(686, 3);
-            this.mAnimationStopButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.mAnimationStopButton.Name = "mAnimationStopButton";
-            this.mAnimationStopButton.Size = new System.Drawing.Size(156, 34);
-            this.mAnimationStopButton.TabIndex = 2;
-            this.mAnimationStopButton.Text = "Stop";
-            this.mAnimationStopButton.UseVisualStyleBackColor = true;
-            this.mAnimationStopButton.Click += new System.EventHandler(this.HandleAnimationStopButtonClick);
-            // 
-            // mAnimationPlaybackButton
-            // 
-            this.mAnimationPlaybackButton.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.mAnimationPlaybackButton.Location = new System.Drawing.Point(604, 3);
-            this.mAnimationPlaybackButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.mAnimationPlaybackButton.Name = "mAnimationPlaybackButton";
-            this.mAnimationPlaybackButton.Size = new System.Drawing.Size(74, 34);
-            this.mAnimationPlaybackButton.TabIndex = 0;
-            this.mAnimationPlaybackButton.Text = "Play ";
-            this.mAnimationPlaybackButton.UseVisualStyleBackColor = true;
+            tableLayoutPanel_AnimationControls.ColumnCount = 3;
+            tableLayoutPanel_AnimationControls.ColumnStyles.Add( new System.Windows.Forms.ColumnStyle( System.Windows.Forms.SizeType.Percent, 70F ) );
+            tableLayoutPanel_AnimationControls.ColumnStyles.Add( new System.Windows.Forms.ColumnStyle( System.Windows.Forms.SizeType.Percent, 15F ) );
+            tableLayoutPanel_AnimationControls.ColumnStyles.Add( new System.Windows.Forms.ColumnStyle( System.Windows.Forms.SizeType.Percent, 15F ) );
+            tableLayoutPanel_AnimationControls.Controls.Add( mAnimationTrackBar, 0, 0 );
+            tableLayoutPanel_AnimationControls.Controls.Add( mAnimationPlaybackButton, 1, 0 );
+            tableLayoutPanel_AnimationControls.Controls.Add( mAnimationStopButton, 2, 0 );
+            tableLayoutPanel_AnimationControls.Dock = System.Windows.Forms.DockStyle.Fill;
+            tableLayoutPanel_AnimationControls.Location = new System.Drawing.Point( 0, 0 );
+            tableLayoutPanel_AnimationControls.Margin = new System.Windows.Forms.Padding( 5, 4, 5, 4 );
+            tableLayoutPanel_AnimationControls.Name = "tableLayoutPanel_AnimationControls";
+            tableLayoutPanel_AnimationControls.RowCount = 1;
+            tableLayoutPanel_AnimationControls.RowStyles.Add( new System.Windows.Forms.RowStyle( System.Windows.Forms.SizeType.Percent, 100F ) );
+            tableLayoutPanel_AnimationControls.Size = new System.Drawing.Size( 451, 25 );
+            tableLayoutPanel_AnimationControls.TabIndex = 0;
             // 
             // mAnimationTrackBar
             // 
-            this.tableLayoutPanel1.SetColumnSpan(this.mAnimationTrackBar, 6);
-            this.mAnimationTrackBar.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.mAnimationTrackBar.Location = new System.Drawing.Point(4, 3);
-            this.mAnimationTrackBar.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.mAnimationTrackBar.Name = "mAnimationTrackBar";
-            this.mAnimationTrackBar.Size = new System.Drawing.Size(592, 34);
-            this.mAnimationTrackBar.TabIndex = 1;
+            mAnimationTrackBar.Dock = System.Windows.Forms.DockStyle.Fill;
+            mAnimationTrackBar.Location = new System.Drawing.Point( 5, 4 );
+            mAnimationTrackBar.Margin = new System.Windows.Forms.Padding( 5, 4, 5, 4 );
+            mAnimationTrackBar.Name = "mAnimationTrackBar";
+            mAnimationTrackBar.Size = new System.Drawing.Size( 305, 17 );
+            mAnimationTrackBar.TabIndex = 1;
+            // 
+            // mAnimationPlaybackButton
+            // 
+            mAnimationPlaybackButton.DisabledBackColor = System.Drawing.Color.FromArgb(   120  ,   65  ,   177  ,   225   );
+            mAnimationPlaybackButton.DisabledBorderColor = System.Drawing.Color.FromArgb(   120  ,   65  ,   177  ,   225   );
+            mAnimationPlaybackButton.DisabledForeColor = System.Drawing.Color.Gray;
+            mAnimationPlaybackButton.Dock = System.Windows.Forms.DockStyle.Fill;
+            mAnimationPlaybackButton.Font = new System.Drawing.Font( "Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            mAnimationPlaybackButton.HoverBorderColor = System.Drawing.Color.FromArgb(   95  ,   207  ,   255   );
+            mAnimationPlaybackButton.HoverColor = System.Drawing.Color.FromArgb(   95  ,   207  ,   255   );
+            mAnimationPlaybackButton.HoverTextColor = System.Drawing.Color.White;
+            mAnimationPlaybackButton.IsDerivedStyle = true;
+            mAnimationPlaybackButton.Location = new System.Drawing.Point( 320, 4 );
+            mAnimationPlaybackButton.Margin = new System.Windows.Forms.Padding( 5, 4, 5, 4 );
+            mAnimationPlaybackButton.MaximumSize = new System.Drawing.Size( 100, 30 );
+            mAnimationPlaybackButton.Name = "mAnimationPlaybackButton";
+            mAnimationPlaybackButton.NormalBorderColor = System.Drawing.Color.FromArgb(   65  ,   177  ,   225   );
+            mAnimationPlaybackButton.NormalColor = System.Drawing.Color.FromArgb(   65  ,   177  ,   225   );
+            mAnimationPlaybackButton.NormalTextColor = System.Drawing.Color.White;
+            mAnimationPlaybackButton.Padding = new System.Windows.Forms.Padding( 5 );
+            mAnimationPlaybackButton.PressBorderColor = System.Drawing.Color.FromArgb(   35  ,   147  ,   195   );
+            mAnimationPlaybackButton.PressColor = System.Drawing.Color.FromArgb(   35  ,   147  ,   195   );
+            mAnimationPlaybackButton.PressTextColor = System.Drawing.Color.White;
+            mAnimationPlaybackButton.Size = new System.Drawing.Size( 57, 17 );
+            mAnimationPlaybackButton.Style = MetroSet_UI.Enums.Style.Dark;
+            mAnimationPlaybackButton.StyleManager = null;
+            mAnimationPlaybackButton.TabIndex = 0;
+            mAnimationPlaybackButton.Text = "▶";
+            mAnimationPlaybackButton.ThemeAuthor = "Narwin";
+            mAnimationPlaybackButton.ThemeName = "MetroDark";
+            // 
+            // mAnimationStopButton
+            // 
+            mAnimationStopButton.DisabledBackColor = System.Drawing.Color.FromArgb(   120  ,   65  ,   177  ,   225   );
+            mAnimationStopButton.DisabledBorderColor = System.Drawing.Color.FromArgb(   120  ,   65  ,   177  ,   225   );
+            mAnimationStopButton.DisabledForeColor = System.Drawing.Color.Gray;
+            mAnimationStopButton.Dock = System.Windows.Forms.DockStyle.Fill;
+            mAnimationStopButton.Font = new System.Drawing.Font( "Microsoft Sans Serif", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            mAnimationStopButton.HoverBorderColor = System.Drawing.Color.FromArgb(   95  ,   207  ,   255   );
+            mAnimationStopButton.HoverColor = System.Drawing.Color.FromArgb(   95  ,   207  ,   255   );
+            mAnimationStopButton.HoverTextColor = System.Drawing.Color.White;
+            mAnimationStopButton.IsDerivedStyle = true;
+            mAnimationStopButton.Location = new System.Drawing.Point( 387, 4 );
+            mAnimationStopButton.Margin = new System.Windows.Forms.Padding( 5, 4, 5, 4 );
+            mAnimationStopButton.MaximumSize = new System.Drawing.Size( 100, 30 );
+            mAnimationStopButton.Name = "mAnimationStopButton";
+            mAnimationStopButton.NormalBorderColor = System.Drawing.Color.FromArgb(   65  ,   177  ,   225   );
+            mAnimationStopButton.NormalColor = System.Drawing.Color.FromArgb(   65  ,   177  ,   225   );
+            mAnimationStopButton.NormalTextColor = System.Drawing.Color.White;
+            mAnimationStopButton.Padding = new System.Windows.Forms.Padding( 5 );
+            mAnimationStopButton.PressBorderColor = System.Drawing.Color.FromArgb(   35  ,   147  ,   195   );
+            mAnimationStopButton.PressColor = System.Drawing.Color.FromArgb(   35  ,   147  ,   195   );
+            mAnimationStopButton.PressTextColor = System.Drawing.Color.White;
+            mAnimationStopButton.Size = new System.Drawing.Size( 59, 17 );
+            mAnimationStopButton.Style = MetroSet_UI.Enums.Style.Light;
+            mAnimationStopButton.StyleManager = null;
+            mAnimationStopButton.TabIndex = 2;
+            mAnimationStopButton.Text = "■";
+            mAnimationStopButton.ThemeAuthor = "Narwin";
+            mAnimationStopButton.ThemeName = "MetroLite";
+            mAnimationStopButton.Click += HandleAnimationStopButtonClick;
+            // 
+            // splitContainer_Main
+            // 
+            splitContainer_Main.Dock = System.Windows.Forms.DockStyle.Fill;
+            splitContainer_Main.Location = new System.Drawing.Point( 2, 30 );
+            splitContainer_Main.Name = "splitContainer_Main";
+            // 
+            // splitContainer_Main.Panel1
+            // 
+            splitContainer_Main.Panel1.Controls.Add( splitContainer_LeftSide );
+            // 
+            // splitContainer_Main.Panel2
+            // 
+            splitContainer_Main.Panel2.Controls.Add( splitContainer_RightSide );
+            splitContainer_Main.Size = new System.Drawing.Size( 878, 521 );
+            splitContainer_Main.SplitterDistance = 451;
+            splitContainer_Main.TabIndex = 5;
+            // 
+            // splitContainer_LeftSide
+            // 
+            splitContainer_LeftSide.Dock = System.Windows.Forms.DockStyle.Fill;
+            splitContainer_LeftSide.Location = new System.Drawing.Point( 0, 0 );
+            splitContainer_LeftSide.Name = "splitContainer_LeftSide";
+            splitContainer_LeftSide.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            // 
+            // splitContainer_LeftSide.Panel1
+            // 
+            splitContainer_LeftSide.Panel1.Controls.Add( mContentPanel );
+            // 
+            // splitContainer_LeftSide.Panel2
+            // 
+            splitContainer_LeftSide.Panel2.Controls.Add( tableLayoutPanel_AnimationControls );
+            splitContainer_LeftSide.Size = new System.Drawing.Size( 451, 521 );
+            splitContainer_LeftSide.SplitterDistance = 492;
+            splitContainer_LeftSide.TabIndex = 7;
+            // 
+            // splitContainer_RightSide
+            // 
+            splitContainer_RightSide.Dock = System.Windows.Forms.DockStyle.Fill;
+            splitContainer_RightSide.Location = new System.Drawing.Point( 0, 0 );
+            splitContainer_RightSide.Name = "splitContainer_RightSide";
+            splitContainer_RightSide.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            // 
+            // splitContainer_RightSide.Panel1
+            // 
+            splitContainer_RightSide.Panel1.Controls.Add( tabControl1 );
+            // 
+            // splitContainer_RightSide.Panel2
+            // 
+            splitContainer_RightSide.Panel2.Controls.Add( panel_PropertyGridContainer );
+            splitContainer_RightSide.Size = new System.Drawing.Size( 423, 521 );
+            splitContainer_RightSide.SplitterDistance = 225;
+            splitContainer_RightSide.TabIndex = 0;
+            // 
+            // panel_PropertyGridContainer
+            // 
+            panel_PropertyGridContainer.Controls.Add( mPropertyGrid );
+            panel_PropertyGridContainer.Dock = System.Windows.Forms.DockStyle.Fill;
+            panel_PropertyGridContainer.Location = new System.Drawing.Point( 0, 0 );
+            panel_PropertyGridContainer.Margin = new System.Windows.Forms.Padding( 25 );
+            panel_PropertyGridContainer.Name = "panel_PropertyGridContainer";
+            panel_PropertyGridContainer.Padding = new System.Windows.Forms.Padding( 0, 0, 5, 5 );
+            panel_PropertyGridContainer.Size = new System.Drawing.Size( 423, 292 );
+            panel_PropertyGridContainer.TabIndex = 0;
+            // 
+            // mPropertyGrid
+            // 
+            mPropertyGrid.CategoryForeColor = System.Drawing.Color.Silver;
+            mPropertyGrid.CommandsBorderColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            mPropertyGrid.CommandsForeColor = System.Drawing.Color.Silver;
+            mPropertyGrid.DisabledItemForeColor = System.Drawing.Color.FromArgb(   127  ,   192  ,   192  ,   192   );
+            mPropertyGrid.Dock = System.Windows.Forms.DockStyle.Fill;
+            mPropertyGrid.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            mPropertyGrid.HelpBackColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            mPropertyGrid.HelpBorderColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            mPropertyGrid.HelpForeColor = System.Drawing.Color.Silver;
+            mPropertyGrid.LineColor = System.Drawing.SystemColors.ControlDarkDark;
+            mPropertyGrid.Location = new System.Drawing.Point( 0, 0 );
+            mPropertyGrid.Margin = new System.Windows.Forms.Padding( 5, 4, 5, 4 );
+            mPropertyGrid.Name = "mPropertyGrid";
+            mPropertyGrid.PropertySort = System.Windows.Forms.PropertySort.NoSort;
+            mPropertyGrid.Size = new System.Drawing.Size( 418, 287 );
+            mPropertyGrid.TabIndex = 5;
+            mPropertyGrid.ToolbarVisible = false;
+            mPropertyGrid.ViewBackColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            mPropertyGrid.ViewBorderColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            mPropertyGrid.ViewForeColor = System.Drawing.Color.Silver;
             // 
             // MainForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1461, 864);
-            this.Controls.Add(this.tableLayoutPanel1);
-            this.Controls.Add(this.tabControl1);
-            this.Controls.Add(this.mPropertyGrid);
-            this.Controls.Add(this.mMainMenuStrip);
-            this.Controls.Add(this.mContentPanel);
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.MainMenuStrip = this.mMainMenuStrip;
-            this.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.Name = "MainForm";
-            this.Text = "GFD Studio";
-            this.mMainMenuStrip.ResumeLayout(false);
-            this.mMainMenuStrip.PerformLayout();
-            this.tabControl1.ResumeLayout(false);
-            this.tabPage1.ResumeLayout(false);
-            this.tabPage2.ResumeLayout(false);
-            this.tableLayoutPanel1.ResumeLayout(false);
-            this.tableLayoutPanel1.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.mAnimationTrackBar)).EndInit();
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            BackColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            BackgroundColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            ClientSize = new System.Drawing.Size( 882, 553 );
+            Controls.Add( splitContainer_Main );
+            Controls.Add( mMainMenuStrip );
+            DropShadowEffect = false;
+            FormBorderStyle = System.Windows.Forms.FormBorderStyle.Sizable;
+            HeaderHeight = -40;
+            Icon = (System.Drawing.Icon) resources.GetObject( "$this.Icon" ) ;
+            MainMenuStrip = mMainMenuStrip;
+            Margin = new System.Windows.Forms.Padding( 5, 4, 5, 4 );
+            Name = "MainForm";
+            Opacity = 0.99D;
+            Padding = new System.Windows.Forms.Padding( 2, 0, 2, 2 );
+            ShowHeader = true;
+            ShowLeftRect = false;
+            SizeGripStyle = System.Windows.Forms.SizeGripStyle.Show;
+            Style = MetroSet_UI.Enums.Style.Dark;
+            Text = "GFD STUDIO";
+            TextColor = System.Drawing.Color.White;
+            ThemeName = "MetroDark";
+            mMainMenuStrip.ResumeLayout( false );
+            mMainMenuStrip.PerformLayout();
+            tabControl1.ResumeLayout( false );
+            tabPage1.ResumeLayout( false );
+            tabPage2.ResumeLayout( false );
+            tableLayoutPanel_AnimationControls.ResumeLayout( false );
+            tableLayoutPanel_AnimationControls.PerformLayout();
+            ( (System.ComponentModel.ISupportInitialize) mAnimationTrackBar  ).EndInit();
+            splitContainer_Main.Panel1.ResumeLayout( false );
+            splitContainer_Main.Panel2.ResumeLayout( false );
+            ( (System.ComponentModel.ISupportInitialize) splitContainer_Main  ).EndInit();
+            splitContainer_Main.ResumeLayout( false );
+            splitContainer_LeftSide.Panel1.ResumeLayout( false );
+            splitContainer_LeftSide.Panel2.ResumeLayout( false );
+            ( (System.ComponentModel.ISupportInitialize) splitContainer_LeftSide  ).EndInit();
+            splitContainer_LeftSide.ResumeLayout( false );
+            splitContainer_RightSide.Panel1.ResumeLayout( false );
+            splitContainer_RightSide.Panel2.ResumeLayout( false );
+            ( (System.ComponentModel.ISupportInitialize) splitContainer_RightSide  ).EndInit();
+            splitContainer_RightSide.ResumeLayout( false );
+            panel_PropertyGridContainer.ResumeLayout( false );
+            ResumeLayout( false );
+            PerformLayout();
         }
 
         #endregion
 
-        private GFDStudio.GUI.DataViewNodes.DataTreeView mModelEditorTreeView;
+        private DataTreeView mModelEditorTreeView;
         private System.Windows.Forms.MenuStrip mMainMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem mFileToolStripMenuItem;
-        private System.Windows.Forms.PropertyGrid mPropertyGrid;
         private System.Windows.Forms.ToolStripMenuItem mOpenToolStripMenuItem;
         private System.Windows.Forms.Panel mContentPanel;
         private System.Windows.Forms.ToolStripMenuItem saveToolStripMenuItem;
@@ -442,14 +674,14 @@ namespace GFDStudio.GUI.Forms
         private System.Windows.Forms.ToolStripMenuItem makeRelativeToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem animationToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem loadExternalToolStripMenuItem;
-        private System.Windows.Forms.TabControl tabControl1;
-        private System.Windows.Forms.TabPage tabPage1;
-        private System.Windows.Forms.TabPage tabPage2;
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
-        private System.Windows.Forms.Button mAnimationPlaybackButton;
+        private MetroSetTabControl tabControl1;
+        private MetroSetSetTabPage tabPage1;
+        private MetroSetSetTabPage tabPage2;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel_AnimationControls;
+        private MetroSetButton mAnimationPlaybackButton;
         private System.Windows.Forms.TrackBar mAnimationTrackBar;
         private DataTreeView mAnimationListTreeView;
-        private System.Windows.Forms.Button mAnimationStopButton;
+        private MetroSetButton mAnimationStopButton;
         private System.Windows.Forms.ToolStripMenuItem rescaleAnimationPacksInDirectoryToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem convertAnimationsToP5InDirectoryToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem convertMaterialInDirectoryToolStripMenuItem;
@@ -461,5 +693,11 @@ namespace GFDStudio.GUI.Forms
         private System.Windows.Forms.ToolStripMenuItem thereIsNoHelpToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem perishToolStripMenuItem;
         public System.Windows.Forms.ToolStripMenuItem retainTexNameToolStripMenuItem;
+        private System.Windows.Forms.SplitContainer splitContainer_Main;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel_Leftside;
+        private System.Windows.Forms.SplitContainer splitContainer_RightSide;
+        private System.Windows.Forms.Panel panel_PropertyGridContainer;
+        private System.Windows.Forms.PropertyGrid mPropertyGrid;
+        private System.Windows.Forms.SplitContainer splitContainer_LeftSide;
     }
 }

--- a/GFDStudio/GUI/Forms/MainForm.cs
+++ b/GFDStudio/GUI/Forms/MainForm.cs
@@ -1,15 +1,17 @@
 ﻿using System;
 using System.Linq;
+using System.Windows.Controls;
 using System.Windows.Forms;
 using GFDLibrary;
 using GFDLibrary.Animations;
 using GFDStudio.FormatModules;
 using GFDStudio.GUI.Controls;
 using GFDStudio.GUI.DataViewNodes;
+using MetroSet_UI.Forms;
 
 namespace GFDStudio.GUI.Forms
 {
-    public partial class MainForm : Form
+    public partial class MainForm : MetroSet_UI.Forms.MetroSetForm
     {
         private static MainForm sInstance;
         public static MainForm Instance
@@ -40,6 +42,7 @@ namespace GFDStudio.GUI.Forms
         public MainForm()
         {
             InitializeComponent();
+            mMainMenuStrip.Renderer = new CustomMenuRenderer();
             InitializeState();
             InitializeEvents();
 
@@ -185,7 +188,7 @@ namespace GFDStudio.GUI.Forms
 
         public void UpdateSelection()
         {
-            var selectedNode = ( DataViewNode )mPropertyGrid.SelectedObject;
+            var selectedNode = (DataViewNode)mPropertyGrid.SelectedObject;
             if ( selectedNode != null )
                 UpdateSelection( selectedNode );
         }
@@ -195,7 +198,7 @@ namespace GFDStudio.GUI.Forms
             // Set property grid to display properties of the currently selected node
             mPropertyGrid.SelectedObject = node;
 
-            Control control = null;
+            System.Windows.Forms.Control control = null;
 
             if ( FormatModuleRegistry.ModuleByType.TryGetValue( node.DataType, out var module ) )
             {
@@ -207,13 +210,13 @@ namespace GFDStudio.GUI.Forms
                 }
                 else if ( module.ModelType == typeof( ModelPack ) )
                 {
-                    ModelViewControl.Instance.LoadModel( ( ModelPack )node.Data );
+                    ModelViewControl.Instance.LoadModel( (ModelPack)node.Data );
                     ModelViewControl.Instance.Visible = false;
                     control = ModelViewControl.Instance;
                 }
                 else if ( node.DataType == typeof( Animation ) )
                 {
-                    ModelViewControl.Instance.LoadAnimation( ( Animation ) node.Data );
+                    ModelViewControl.Instance.LoadAnimation( (Animation)node.Data );
                 }
             }
 

--- a/GFDStudio/GUI/Forms/MainForm.resx
+++ b/GFDStudio/GUI/Forms/MainForm.resx
@@ -1,24 +1,24 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
+  <!--
     Microsoft ResX Schema 
-    
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
     <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
     <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
     <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing"">Blue</data>
     <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
         <value>[base64 mime encoded serialized .NET Framework object]</value>
     </data>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
     
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -121,7 +121,7 @@
     <value>17, 17</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>63</value>
+    <value>82</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/GFDStudio/GUI/Forms/ModelConverterOptionsDialog.Designer.cs
+++ b/GFDStudio/GUI/Forms/ModelConverterOptionsDialog.Designer.cs
@@ -1,6 +1,9 @@
-﻿namespace GFDStudio.GUI.Forms
+﻿using MetroSet_UI.Controls;
+using MetroSet_UI.Forms;
+
+namespace GFDStudio.GUI.Forms
 {
-    partial class ModelConverterOptionsDialog
+    partial class ModelConverterOptionsDialog : MetroSetForm
     {
         /// <summary>
         /// Required designer variable.
@@ -28,250 +31,368 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ModelConverterOptionsDialog));
-            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.VersionLabel = new System.Windows.Forms.Label();
-            this.MaterialPresetLabel = new System.Windows.Forms.Label();
-            this.MaterialPresetComboBox = new System.Windows.Forms.ComboBox();
-            this.VersionTextBox = new System.Windows.Forms.TextBox();
-            this.ConvertSkinToZUpLabel = new System.Windows.Forms.Label();
-            this.ConvertSkinToZUpCheckBox = new System.Windows.Forms.CheckBox();
-            this.GenerateVertexColorsCheckBox = new System.Windows.Forms.CheckBox();
-            this.GenerateVertexColorsLabel = new System.Windows.Forms.Label();
-            this.minVertexAttributesLabel = new System.Windows.Forms.Label();
-            this.MinimalVertexAttributesCheckBox = new System.Windows.Forms.CheckBox();
-            this.ConvertButton = new System.Windows.Forms.Button();
-            this.CancelButton = new System.Windows.Forms.Button();
-            this.descriptionTooltip = new System.Windows.Forms.ToolTip(this.components);
-            this.OpenPresetButton = new System.Windows.Forms.Button();
-            this.tableLayoutPanel1.SuspendLayout();
-            this.SuspendLayout();
+            components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager( typeof( ModelConverterOptionsDialog ) );
+            tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            VersionLabel = new MetroSetLabel();
+            MaterialPresetLabel = new MetroSetLabel();
+            MaterialPresetComboBox = new System.Windows.Forms.ComboBox();
+            VersionTextBox = new MetroSetTextBox();
+            ConvertSkinToZUpLabel = new MetroSetLabel();
+            ConvertSkinToZUpCheckBox = new MetroSetCheckBox();
+            GenerateVertexColorsCheckBox = new MetroSetCheckBox();
+            GenerateVertexColorsLabel = new MetroSetLabel();
+            minVertexAttributesLabel = new MetroSetLabel();
+            MinimalVertexAttributesCheckBox = new MetroSetCheckBox();
+            descriptionTooltip = new System.Windows.Forms.ToolTip( components );
+            OpenPresetButton = new System.Windows.Forms.Button();
+            tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+            CancelButton = new System.Windows.Forms.Button();
+            ConvertButton = new System.Windows.Forms.Button();
+            tableLayoutPanel1.SuspendLayout();
+            tableLayoutPanel2.SuspendLayout();
+            SuspendLayout();
             // 
             // tableLayoutPanel1
             // 
-            this.tableLayoutPanel1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.tableLayoutPanel1.ColumnCount = 2;
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel1.Controls.Add(this.VersionLabel, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this.MaterialPresetLabel, 0, 1);
-            this.tableLayoutPanel1.Controls.Add(this.MaterialPresetComboBox, 1, 1);
-            this.tableLayoutPanel1.Controls.Add(this.VersionTextBox, 1, 0);
-            this.tableLayoutPanel1.Controls.Add(this.ConvertSkinToZUpLabel, 0, 2);
-            this.tableLayoutPanel1.Controls.Add(this.ConvertSkinToZUpCheckBox, 1, 2);
-            this.tableLayoutPanel1.Controls.Add(this.GenerateVertexColorsCheckBox, 1, 3);
-            this.tableLayoutPanel1.Controls.Add(this.GenerateVertexColorsLabel, 0, 3);
-            this.tableLayoutPanel1.Controls.Add(this.minVertexAttributesLabel, 0, 4);
-            this.tableLayoutPanel1.Controls.Add(this.MinimalVertexAttributesCheckBox, 1, 4);
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(14, 14);
-            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            this.tableLayoutPanel1.RowCount = 5;
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 20F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 20F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 20F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 20F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 20F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(385, 143);
-            this.tableLayoutPanel1.TabIndex = 0;
+            tableLayoutPanel1.ColumnCount = 2;
+            tableLayoutPanel1.ColumnStyles.Add( new System.Windows.Forms.ColumnStyle( System.Windows.Forms.SizeType.Percent, 50F ) );
+            tableLayoutPanel1.ColumnStyles.Add( new System.Windows.Forms.ColumnStyle( System.Windows.Forms.SizeType.Percent, 50F ) );
+            tableLayoutPanel1.Controls.Add( VersionLabel, 0, 0 );
+            tableLayoutPanel1.Controls.Add( MaterialPresetLabel, 0, 1 );
+            tableLayoutPanel1.Controls.Add( MaterialPresetComboBox, 1, 1 );
+            tableLayoutPanel1.Controls.Add( VersionTextBox, 1, 0 );
+            tableLayoutPanel1.Controls.Add( ConvertSkinToZUpLabel, 0, 2 );
+            tableLayoutPanel1.Controls.Add( ConvertSkinToZUpCheckBox, 1, 2 );
+            tableLayoutPanel1.Controls.Add( GenerateVertexColorsCheckBox, 1, 3 );
+            tableLayoutPanel1.Controls.Add( GenerateVertexColorsLabel, 0, 3 );
+            tableLayoutPanel1.Controls.Add( minVertexAttributesLabel, 0, 4 );
+            tableLayoutPanel1.Controls.Add( MinimalVertexAttributesCheckBox, 1, 4 );
+            tableLayoutPanel1.Controls.Add( tableLayoutPanel2, 1, 6 );
+            tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            tableLayoutPanel1.Location = new System.Drawing.Point( 2, 0 );
+            tableLayoutPanel1.Margin = new System.Windows.Forms.Padding( 4, 3, 4, 3 );
+            tableLayoutPanel1.Name = "tableLayoutPanel1";
+            tableLayoutPanel1.RowCount = 7;
+            tableLayoutPanel1.RowStyles.Add( new System.Windows.Forms.RowStyle( System.Windows.Forms.SizeType.Percent, 16.666666F ) );
+            tableLayoutPanel1.RowStyles.Add( new System.Windows.Forms.RowStyle( System.Windows.Forms.SizeType.Percent, 16.666666F ) );
+            tableLayoutPanel1.RowStyles.Add( new System.Windows.Forms.RowStyle( System.Windows.Forms.SizeType.Percent, 11.1111107F ) );
+            tableLayoutPanel1.RowStyles.Add( new System.Windows.Forms.RowStyle( System.Windows.Forms.SizeType.Percent, 11.1111107F ) );
+            tableLayoutPanel1.RowStyles.Add( new System.Windows.Forms.RowStyle( System.Windows.Forms.SizeType.Percent, 11.1111107F ) );
+            tableLayoutPanel1.RowStyles.Add( new System.Windows.Forms.RowStyle( System.Windows.Forms.SizeType.Percent, 11.1111107F ) );
+            tableLayoutPanel1.RowStyles.Add( new System.Windows.Forms.RowStyle( System.Windows.Forms.SizeType.Percent, 22.2222214F ) );
+            tableLayoutPanel1.Size = new System.Drawing.Size( 426, 323 );
+            tableLayoutPanel1.TabIndex = 0;
             // 
             // VersionLabel
             // 
-            this.VersionLabel.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.VersionLabel.AutoSize = true;
-            this.VersionLabel.Location = new System.Drawing.Point(98, 6);
-            this.VersionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.VersionLabel.Name = "VersionLabel";
-            this.VersionLabel.Size = new System.Drawing.Size(45, 15);
-            this.VersionLabel.TabIndex = 2;
-            this.VersionLabel.Text = "Version";
-            this.VersionLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            this.descriptionTooltip.SetToolTip(this.VersionLabel, "Resource version to use on model/animation pack.\r\n\r\nKnown resource versions:\r\n0x0" +
-        "1105030 - P4D\r\n0x01105070 - P5\r\n0x01105090 - P3D & P5D\r\n0x01105100 - P5R & CFB");
+            VersionLabel.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            VersionLabel.AutoSize = true;
+            VersionLabel.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            VersionLabel.IsDerivedStyle = true;
+            VersionLabel.Location = new System.Drawing.Point( 143, 16 );
+            VersionLabel.Margin = new System.Windows.Forms.Padding( 4, 0, 4, 0 );
+            VersionLabel.Name = "VersionLabel";
+            VersionLabel.Size = new System.Drawing.Size( 66, 20 );
+            VersionLabel.Style = MetroSet_UI.Enums.Style.Dark;
+            VersionLabel.StyleManager = null;
+            VersionLabel.TabIndex = 2;
+            VersionLabel.Text = "Version";
+            VersionLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            VersionLabel.ThemeAuthor = "Narwin";
+            VersionLabel.ThemeName = "MetroDark";
+            descriptionTooltip.SetToolTip( VersionLabel, "Resource version to use on model/animation pack.\r\n\r\nKnown resource versions:\r\n0x01105030 - P4D\r\n0x01105070 - P5\r\n0x01105090 - P3D & P5D\r\n0x01105100 - P5R & CFB" );
             // 
             // MaterialPresetLabel
             // 
-            this.MaterialPresetLabel.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.MaterialPresetLabel.AutoSize = true;
-            this.MaterialPresetLabel.Location = new System.Drawing.Point(58, 34);
-            this.MaterialPresetLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.MaterialPresetLabel.Name = "MaterialPresetLabel";
-            this.MaterialPresetLabel.Size = new System.Drawing.Size(85, 15);
-            this.MaterialPresetLabel.TabIndex = 0;
-            this.MaterialPresetLabel.Text = "Material preset";
-            this.descriptionTooltip.SetToolTip(this.MaterialPresetLabel, "Material Preset to apply to converted model.");
+            MaterialPresetLabel.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            MaterialPresetLabel.AutoSize = true;
+            MaterialPresetLabel.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            MaterialPresetLabel.IsDerivedStyle = true;
+            MaterialPresetLabel.Location = new System.Drawing.Point( 88, 69 );
+            MaterialPresetLabel.Margin = new System.Windows.Forms.Padding( 4, 0, 4, 0 );
+            MaterialPresetLabel.Name = "MaterialPresetLabel";
+            MaterialPresetLabel.Size = new System.Drawing.Size( 121, 20 );
+            MaterialPresetLabel.Style = MetroSet_UI.Enums.Style.Dark;
+            MaterialPresetLabel.StyleManager = null;
+            MaterialPresetLabel.TabIndex = 0;
+            MaterialPresetLabel.Text = "Material preset";
+            MaterialPresetLabel.ThemeAuthor = "Narwin";
+            MaterialPresetLabel.ThemeName = "MetroDark";
+            descriptionTooltip.SetToolTip( MaterialPresetLabel, "Material Preset to apply to converted model." );
             // 
             // MaterialPresetComboBox
             // 
-            this.MaterialPresetComboBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.MaterialPresetComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.MaterialPresetComboBox.Location = new System.Drawing.Point(151, 31);
-            this.MaterialPresetComboBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.MaterialPresetComboBox.Name = "MaterialPresetComboBox";
-            this.MaterialPresetComboBox.Size = new System.Drawing.Size(226, 23);
-            this.MaterialPresetComboBox.TabIndex = 1;
+            MaterialPresetComboBox.Anchor =   System.Windows.Forms.AnchorStyles.Left  |  System.Windows.Forms.AnchorStyles.Right  ;
+            MaterialPresetComboBox.BackColor = System.Drawing.Color.FromArgb(   20  ,   20  ,   20   );
+            MaterialPresetComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            MaterialPresetComboBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            MaterialPresetComboBox.ForeColor = System.Drawing.Color.Silver;
+            MaterialPresetComboBox.Location = new System.Drawing.Point( 217, 65 );
+            MaterialPresetComboBox.Margin = new System.Windows.Forms.Padding( 4, 3, 4, 3 );
+            MaterialPresetComboBox.Name = "MaterialPresetComboBox";
+            MaterialPresetComboBox.Size = new System.Drawing.Size( 205, 34 );
+            MaterialPresetComboBox.TabIndex = 1;
             // 
             // VersionTextBox
             // 
-            this.VersionTextBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.VersionTextBox.Location = new System.Drawing.Point(151, 3);
-            this.VersionTextBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.VersionTextBox.Name = "VersionTextBox";
-            this.VersionTextBox.Size = new System.Drawing.Size(226, 23);
-            this.VersionTextBox.TabIndex = 3;
+            VersionTextBox.Anchor =   System.Windows.Forms.AnchorStyles.Left  |  System.Windows.Forms.AnchorStyles.Right  ;
+            VersionTextBox.AutoCompleteCustomSource = null;
+            VersionTextBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.None;
+            VersionTextBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.None;
+            VersionTextBox.BorderColor = System.Drawing.Color.FromArgb(   110  ,   110  ,   110   );
+            VersionTextBox.DisabledBackColor = System.Drawing.Color.FromArgb(   80  ,   80  ,   80   );
+            VersionTextBox.DisabledBorderColor = System.Drawing.Color.FromArgb(   109  ,   109  ,   109   );
+            VersionTextBox.DisabledForeColor = System.Drawing.Color.FromArgb(   109  ,   109  ,   109   );
+            VersionTextBox.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            VersionTextBox.HoverColor = System.Drawing.Color.FromArgb(   65  ,   177  ,   225   );
+            VersionTextBox.Image = null;
+            VersionTextBox.IsDerivedStyle = true;
+            VersionTextBox.Lines = null;
+            VersionTextBox.Location = new System.Drawing.Point( 217, 11 );
+            VersionTextBox.Margin = new System.Windows.Forms.Padding( 4, 3, 4, 3 );
+            VersionTextBox.MaxLength = 32767;
+            VersionTextBox.Multiline = false;
+            VersionTextBox.Name = "VersionTextBox";
+            VersionTextBox.ReadOnly = false;
+            VersionTextBox.Size = new System.Drawing.Size( 205, 30 );
+            VersionTextBox.Style = MetroSet_UI.Enums.Style.Dark;
+            VersionTextBox.StyleManager = null;
+            VersionTextBox.TabIndex = 3;
+            VersionTextBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Left;
+            VersionTextBox.ThemeAuthor = "Narwin";
+            VersionTextBox.ThemeName = "MetroDark";
+            VersionTextBox.UseSystemPasswordChar = false;
+            VersionTextBox.WatermarkText = "";
             // 
             // ConvertSkinToZUpLabel
             // 
-            this.ConvertSkinToZUpLabel.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.ConvertSkinToZUpLabel.AutoSize = true;
-            this.ConvertSkinToZUpLabel.Location = new System.Drawing.Point(29, 62);
-            this.ConvertSkinToZUpLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.ConvertSkinToZUpLabel.Name = "ConvertSkinToZUpLabel";
-            this.ConvertSkinToZUpLabel.Size = new System.Drawing.Size(114, 15);
-            this.ConvertSkinToZUpLabel.TabIndex = 4;
-            this.ConvertSkinToZUpLabel.Text = "Convert skin to Z up";
-            this.descriptionTooltip.SetToolTip(this.ConvertSkinToZUpLabel, "Convert the up axis of the inverse bind pose matrices to Z-up.");
+            ConvertSkinToZUpLabel.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            ConvertSkinToZUpLabel.AutoSize = true;
+            ConvertSkinToZUpLabel.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            ConvertSkinToZUpLabel.IsDerivedStyle = true;
+            ConvertSkinToZUpLabel.Location = new System.Drawing.Point( 51, 113 );
+            ConvertSkinToZUpLabel.Margin = new System.Windows.Forms.Padding( 4, 0, 4, 0 );
+            ConvertSkinToZUpLabel.Name = "ConvertSkinToZUpLabel";
+            ConvertSkinToZUpLabel.Size = new System.Drawing.Size( 158, 20 );
+            ConvertSkinToZUpLabel.Style = MetroSet_UI.Enums.Style.Dark;
+            ConvertSkinToZUpLabel.StyleManager = null;
+            ConvertSkinToZUpLabel.TabIndex = 4;
+            ConvertSkinToZUpLabel.Text = "Convert skin to Z up";
+            ConvertSkinToZUpLabel.ThemeAuthor = "Narwin";
+            ConvertSkinToZUpLabel.ThemeName = "MetroDark";
+            descriptionTooltip.SetToolTip( ConvertSkinToZUpLabel, "Convert the up axis of the inverse bind pose matrices to Z-up." );
             // 
             // ConvertSkinToZUpCheckBox
             // 
-            this.ConvertSkinToZUpCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.ConvertSkinToZUpCheckBox.AutoSize = true;
-            this.ConvertSkinToZUpCheckBox.Location = new System.Drawing.Point(151, 63);
-            this.ConvertSkinToZUpCheckBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.ConvertSkinToZUpCheckBox.Name = "ConvertSkinToZUpCheckBox";
-            this.ConvertSkinToZUpCheckBox.Size = new System.Drawing.Size(15, 14);
-            this.ConvertSkinToZUpCheckBox.TabIndex = 5;
-            this.ConvertSkinToZUpCheckBox.UseVisualStyleBackColor = true;
+            ConvertSkinToZUpCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            ConvertSkinToZUpCheckBox.BackColor = System.Drawing.Color.Transparent;
+            ConvertSkinToZUpCheckBox.BackgroundColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            ConvertSkinToZUpCheckBox.BorderColor = System.Drawing.Color.FromArgb(   155  ,   155  ,   155   );
+            ConvertSkinToZUpCheckBox.Checked = false;
+            ConvertSkinToZUpCheckBox.CheckSignColor = System.Drawing.Color.FromArgb(   65  ,   177  ,   225   );
+            ConvertSkinToZUpCheckBox.CheckState = MetroSet_UI.Enums.CheckState.Unchecked;
+            ConvertSkinToZUpCheckBox.DisabledBorderColor = System.Drawing.Color.FromArgb(   85  ,   85  ,   85   );
+            ConvertSkinToZUpCheckBox.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            ConvertSkinToZUpCheckBox.IsDerivedStyle = true;
+            ConvertSkinToZUpCheckBox.Location = new System.Drawing.Point( 217, 115 );
+            ConvertSkinToZUpCheckBox.Margin = new System.Windows.Forms.Padding( 4, 3, 4, 3 );
+            ConvertSkinToZUpCheckBox.Name = "ConvertSkinToZUpCheckBox";
+            ConvertSkinToZUpCheckBox.SignStyle = MetroSet_UI.Enums.SignStyle.Sign;
+            ConvertSkinToZUpCheckBox.Size = new System.Drawing.Size( 25, 16 );
+            ConvertSkinToZUpCheckBox.Style = MetroSet_UI.Enums.Style.Dark;
+            ConvertSkinToZUpCheckBox.StyleManager = null;
+            ConvertSkinToZUpCheckBox.TabIndex = 5;
+            ConvertSkinToZUpCheckBox.ThemeAuthor = "Narwin";
+            ConvertSkinToZUpCheckBox.ThemeName = "MetroDark";
             // 
             // GenerateVertexColorsCheckBox
             // 
-            this.GenerateVertexColorsCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.GenerateVertexColorsCheckBox.AutoSize = true;
-            this.GenerateVertexColorsCheckBox.Location = new System.Drawing.Point(151, 91);
-            this.GenerateVertexColorsCheckBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.GenerateVertexColorsCheckBox.Name = "GenerateVertexColorsCheckBox";
-            this.GenerateVertexColorsCheckBox.Size = new System.Drawing.Size(15, 14);
-            this.GenerateVertexColorsCheckBox.TabIndex = 6;
-            this.GenerateVertexColorsCheckBox.UseVisualStyleBackColor = true;
+            GenerateVertexColorsCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            GenerateVertexColorsCheckBox.BackColor = System.Drawing.Color.Transparent;
+            GenerateVertexColorsCheckBox.BackgroundColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            GenerateVertexColorsCheckBox.BorderColor = System.Drawing.Color.FromArgb(   155  ,   155  ,   155   );
+            GenerateVertexColorsCheckBox.Checked = false;
+            GenerateVertexColorsCheckBox.CheckSignColor = System.Drawing.Color.FromArgb(   65  ,   177  ,   225   );
+            GenerateVertexColorsCheckBox.CheckState = MetroSet_UI.Enums.CheckState.Unchecked;
+            GenerateVertexColorsCheckBox.DisabledBorderColor = System.Drawing.Color.FromArgb(   85  ,   85  ,   85   );
+            GenerateVertexColorsCheckBox.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            GenerateVertexColorsCheckBox.IsDerivedStyle = true;
+            GenerateVertexColorsCheckBox.Location = new System.Drawing.Point( 217, 150 );
+            GenerateVertexColorsCheckBox.Margin = new System.Windows.Forms.Padding( 4, 3, 4, 3 );
+            GenerateVertexColorsCheckBox.Name = "GenerateVertexColorsCheckBox";
+            GenerateVertexColorsCheckBox.SignStyle = MetroSet_UI.Enums.SignStyle.Sign;
+            GenerateVertexColorsCheckBox.Size = new System.Drawing.Size( 25, 16 );
+            GenerateVertexColorsCheckBox.Style = MetroSet_UI.Enums.Style.Dark;
+            GenerateVertexColorsCheckBox.StyleManager = null;
+            GenerateVertexColorsCheckBox.TabIndex = 6;
+            GenerateVertexColorsCheckBox.ThemeAuthor = "Narwin";
+            GenerateVertexColorsCheckBox.ThemeName = "MetroDark";
             // 
             // GenerateVertexColorsLabel
             // 
-            this.GenerateVertexColorsLabel.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.GenerateVertexColorsLabel.AutoSize = true;
-            this.GenerateVertexColorsLabel.Location = new System.Drawing.Point(19, 90);
-            this.GenerateVertexColorsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.GenerateVertexColorsLabel.Name = "GenerateVertexColorsLabel";
-            this.GenerateVertexColorsLabel.Size = new System.Drawing.Size(124, 15);
-            this.GenerateVertexColorsLabel.TabIndex = 7;
-            this.GenerateVertexColorsLabel.Text = "Generate vertex colors";
-            this.descriptionTooltip.SetToolTip(this.GenerateVertexColorsLabel, "Generates dummy white vertex colors for models with none.\r\nFixes vertex explosion" +
-        " bug in P4D when vertex colors are missing.");
+            GenerateVertexColorsLabel.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            GenerateVertexColorsLabel.AutoSize = true;
+            GenerateVertexColorsLabel.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            GenerateVertexColorsLabel.IsDerivedStyle = true;
+            GenerateVertexColorsLabel.Location = new System.Drawing.Point( 30, 148 );
+            GenerateVertexColorsLabel.Margin = new System.Windows.Forms.Padding( 4, 0, 4, 0 );
+            GenerateVertexColorsLabel.Name = "GenerateVertexColorsLabel";
+            GenerateVertexColorsLabel.Size = new System.Drawing.Size( 179, 20 );
+            GenerateVertexColorsLabel.Style = MetroSet_UI.Enums.Style.Dark;
+            GenerateVertexColorsLabel.StyleManager = null;
+            GenerateVertexColorsLabel.TabIndex = 7;
+            GenerateVertexColorsLabel.Text = "Generate vertex colors";
+            GenerateVertexColorsLabel.ThemeAuthor = "Narwin";
+            GenerateVertexColorsLabel.ThemeName = "MetroDark";
+            descriptionTooltip.SetToolTip( GenerateVertexColorsLabel, "Generates dummy white vertex colors for models with none.\r\nFixes vertex explosion bug in P4D when vertex colors are missing." );
             // 
             // minVertexAttributesLabel
             // 
-            this.minVertexAttributesLabel.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.minVertexAttributesLabel.AutoSize = true;
-            this.minVertexAttributesLabel.Location = new System.Drawing.Point(3, 120);
-            this.minVertexAttributesLabel.Name = "minVertexAttributesLabel";
-            this.minVertexAttributesLabel.Size = new System.Drawing.Size(141, 15);
-            this.minVertexAttributesLabel.TabIndex = 8;
-            this.minVertexAttributesLabel.Text = "Minimal Vertex Attributes";
-            this.minVertexAttributesLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            this.descriptionTooltip.SetToolTip(this.minVertexAttributesLabel, resources.GetString("minVertexAttributesLabel.ToolTip"));
+            minVertexAttributesLabel.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            minVertexAttributesLabel.AutoSize = true;
+            minVertexAttributesLabel.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            minVertexAttributesLabel.IsDerivedStyle = true;
+            minVertexAttributesLabel.Location = new System.Drawing.Point( 13, 183 );
+            minVertexAttributesLabel.Name = "minVertexAttributesLabel";
+            minVertexAttributesLabel.Size = new System.Drawing.Size( 197, 20 );
+            minVertexAttributesLabel.Style = MetroSet_UI.Enums.Style.Dark;
+            minVertexAttributesLabel.StyleManager = null;
+            minVertexAttributesLabel.TabIndex = 8;
+            minVertexAttributesLabel.Text = "Minimal Vertex Attributes";
+            minVertexAttributesLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            minVertexAttributesLabel.ThemeAuthor = "Narwin";
+            minVertexAttributesLabel.ThemeName = "MetroDark";
+            descriptionTooltip.SetToolTip( minVertexAttributesLabel, resources.GetString( "minVertexAttributesLabel.ToolTip" ) );
             // 
             // MinimalVertexAttributesCheckBox
             // 
-            this.MinimalVertexAttributesCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.MinimalVertexAttributesCheckBox.AutoSize = true;
-            this.MinimalVertexAttributesCheckBox.Checked = true;
-            this.MinimalVertexAttributesCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.MinimalVertexAttributesCheckBox.Location = new System.Drawing.Point(151, 120);
-            this.MinimalVertexAttributesCheckBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.MinimalVertexAttributesCheckBox.Name = "MinimalVertexAttributesCheckBox";
-            this.MinimalVertexAttributesCheckBox.Size = new System.Drawing.Size(15, 14);
-            this.MinimalVertexAttributesCheckBox.TabIndex = 9;
-            this.MinimalVertexAttributesCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // ConvertButton
-            // 
-            this.ConvertButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-            this.ConvertButton.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.ConvertButton.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-            this.ConvertButton.Location = new System.Drawing.Point(303, 177);
-            this.ConvertButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.ConvertButton.Name = "ConvertButton";
-            this.ConvertButton.Size = new System.Drawing.Size(88, 27);
-            this.ConvertButton.TabIndex = 1;
-            this.ConvertButton.Text = "Convert";
-            this.ConvertButton.UseVisualStyleBackColor = true;
-            // 
-            // CancelButton
-            // 
-            this.CancelButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-            this.CancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.CancelButton.Location = new System.Drawing.Point(207, 177);
-            this.CancelButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.CancelButton.Name = "CancelButton";
-            this.CancelButton.Size = new System.Drawing.Size(88, 27);
-            this.CancelButton.TabIndex = 2;
-            this.CancelButton.Text = "Cancel";
-            this.CancelButton.UseVisualStyleBackColor = true;
+            MinimalVertexAttributesCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            MinimalVertexAttributesCheckBox.BackColor = System.Drawing.Color.Transparent;
+            MinimalVertexAttributesCheckBox.BackgroundColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            MinimalVertexAttributesCheckBox.BorderColor = System.Drawing.Color.FromArgb(   155  ,   155  ,   155   );
+            MinimalVertexAttributesCheckBox.Checked = true;
+            MinimalVertexAttributesCheckBox.CheckSignColor = System.Drawing.Color.FromArgb(   65  ,   177  ,   225   );
+            MinimalVertexAttributesCheckBox.CheckState = MetroSet_UI.Enums.CheckState.Checked;
+            MinimalVertexAttributesCheckBox.DisabledBorderColor = System.Drawing.Color.FromArgb(   85  ,   85  ,   85   );
+            MinimalVertexAttributesCheckBox.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            MinimalVertexAttributesCheckBox.IsDerivedStyle = true;
+            MinimalVertexAttributesCheckBox.Location = new System.Drawing.Point( 217, 185 );
+            MinimalVertexAttributesCheckBox.Margin = new System.Windows.Forms.Padding( 4, 3, 4, 3 );
+            MinimalVertexAttributesCheckBox.Name = "MinimalVertexAttributesCheckBox";
+            MinimalVertexAttributesCheckBox.SignStyle = MetroSet_UI.Enums.SignStyle.Sign;
+            MinimalVertexAttributesCheckBox.Size = new System.Drawing.Size( 25, 16 );
+            MinimalVertexAttributesCheckBox.Style = MetroSet_UI.Enums.Style.Dark;
+            MinimalVertexAttributesCheckBox.StyleManager = null;
+            MinimalVertexAttributesCheckBox.TabIndex = 9;
+            MinimalVertexAttributesCheckBox.ThemeAuthor = "Narwin";
+            MinimalVertexAttributesCheckBox.ThemeName = "MetroDark";
             // 
             // descriptionTooltip
             // 
-            this.descriptionTooltip.AutoPopDelay = 10000;
-            this.descriptionTooltip.InitialDelay = 500;
-            this.descriptionTooltip.ReshowDelay = 100;
+            descriptionTooltip.AutoPopDelay = 10000;
+            descriptionTooltip.InitialDelay = 500;
+            descriptionTooltip.ReshowDelay = 100;
             // 
             // OpenPresetButton
             // 
-            this.OpenPresetButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-            this.OpenPresetButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.OpenPresetButton.Location = new System.Drawing.Point(14, 177);
-            this.OpenPresetButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.OpenPresetButton.Name = "OpenPresetButton";
-            this.OpenPresetButton.Size = new System.Drawing.Size(120, 27);
-            this.OpenPresetButton.TabIndex = 3;
-            this.OpenPresetButton.Text = "Open preset folder";
-            this.OpenPresetButton.UseVisualStyleBackColor = true;
-            this.OpenPresetButton.Click += new System.EventHandler(this.OpenPresetButton_Click);
+            OpenPresetButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+            OpenPresetButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            OpenPresetButton.Location = new System.Drawing.Point( 32, 351 );
+            OpenPresetButton.Margin = new System.Windows.Forms.Padding( 4, 3, 4, 3 );
+            OpenPresetButton.Name = "OpenPresetButton";
+            OpenPresetButton.Size = new System.Drawing.Size( 120, 27 );
+            OpenPresetButton.TabIndex = 3;
+            OpenPresetButton.Text = "Open preset folder";
+            OpenPresetButton.UseVisualStyleBackColor = true;
+            OpenPresetButton.Click += OpenPresetButton_Click;
+            // 
+            // tableLayoutPanel2
+            // 
+            tableLayoutPanel2.ColumnCount = 2;
+            tableLayoutPanel2.ColumnStyles.Add( new System.Windows.Forms.ColumnStyle( System.Windows.Forms.SizeType.Percent, 50F ) );
+            tableLayoutPanel2.ColumnStyles.Add( new System.Windows.Forms.ColumnStyle( System.Windows.Forms.SizeType.Percent, 50F ) );
+            tableLayoutPanel2.Controls.Add( ConvertButton, 1, 0 );
+            tableLayoutPanel2.Controls.Add( CancelButton, 0, 0 );
+            tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
+            tableLayoutPanel2.Location = new System.Drawing.Point( 216, 249 );
+            tableLayoutPanel2.Name = "tableLayoutPanel2";
+            tableLayoutPanel2.RowCount = 1;
+            tableLayoutPanel2.RowStyles.Add( new System.Windows.Forms.RowStyle( System.Windows.Forms.SizeType.Percent, 100F ) );
+            tableLayoutPanel2.Size = new System.Drawing.Size( 207, 71 );
+            tableLayoutPanel2.TabIndex = 10;
+            // 
+            // CancelButton
+            // 
+            CancelButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+            CancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            CancelButton.ForeColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            CancelButton.Location = new System.Drawing.Point( 4, 20 );
+            CancelButton.Margin = new System.Windows.Forms.Padding( 4, 3, 4, 3 );
+            CancelButton.Name = "CancelButton";
+            CancelButton.Size = new System.Drawing.Size( 95, 48 );
+            CancelButton.TabIndex = 4;
+            CancelButton.Text = "Cancel";
+            CancelButton.UseVisualStyleBackColor = true;
+            // 
+            // ConvertButton
+            // 
+            ConvertButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+            ConvertButton.DialogResult = System.Windows.Forms.DialogResult.OK;
+            ConvertButton.Font = new System.Drawing.Font( "Microsoft Sans Serif", 13F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            ConvertButton.ForeColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            ConvertButton.Location = new System.Drawing.Point( 107, 20 );
+            ConvertButton.Margin = new System.Windows.Forms.Padding( 4, 3, 4, 3 );
+            ConvertButton.Name = "ConvertButton";
+            ConvertButton.Size = new System.Drawing.Size( 96, 48 );
+            ConvertButton.TabIndex = 3;
+            ConvertButton.Text = "Convert";
+            ConvertButton.UseVisualStyleBackColor = true;
             // 
             // ModelConverterOptionsDialog
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(404, 216);
-            this.Controls.Add(this.OpenPresetButton);
-            this.Controls.Add(this.CancelButton);
-            this.Controls.Add(this.ConvertButton);
-            this.Controls.Add(this.tableLayoutPanel1);
-            this.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.Name = "ModelConverterOptionsDialog";
-            this.Text = "Model converter options";
-            this.tableLayoutPanel1.ResumeLayout(false);
-            this.tableLayoutPanel1.PerformLayout();
-            this.ResumeLayout(false);
-
+            BackColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            BackgroundColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            ClientSize = new System.Drawing.Size( 430, 325 );
+            Controls.Add( OpenPresetButton );
+            Controls.Add( tableLayoutPanel1 );
+            DropShadowEffect = false;
+            FormBorderStyle = System.Windows.Forms.FormBorderStyle.Sizable;
+            HeaderHeight = -40;
+            Margin = new System.Windows.Forms.Padding( 4, 3, 4, 3 );
+            Name = "ModelConverterOptionsDialog";
+            Opacity = 0.99D;
+            Padding = new System.Windows.Forms.Padding( 2, 0, 2, 2 );
+            ShowHeader = true;
+            ShowLeftRect = false;
+            SizeGripStyle = System.Windows.Forms.SizeGripStyle.Show;
+            StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            Style = MetroSet_UI.Enums.Style.Dark;
+            Text = "MODEL CONVERTER OPTIONS";
+            ThemeName = "MetroDark";
+            tableLayoutPanel1.ResumeLayout( false );
+            tableLayoutPanel1.PerformLayout();
+            tableLayoutPanel2.ResumeLayout( false );
+            ResumeLayout( false );
         }
 
         #endregion
 
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
-        private System.Windows.Forms.Label VersionLabel;
-        private System.Windows.Forms.Label MaterialPresetLabel;
+        private MetroSetLabel VersionLabel;
+        private MetroSetLabel MaterialPresetLabel;
         private System.Windows.Forms.ComboBox MaterialPresetComboBox;
-        private System.Windows.Forms.TextBox VersionTextBox;
-        private System.Windows.Forms.Label ConvertSkinToZUpLabel;
-        private System.Windows.Forms.CheckBox ConvertSkinToZUpCheckBox;
-        private System.Windows.Forms.CheckBox GenerateVertexColorsCheckBox;
-        private System.Windows.Forms.Label GenerateVertexColorsLabel;
-        private System.Windows.Forms.Button ConvertButton;
-        private new System.Windows.Forms.Button CancelButton;
+        private MetroSetTextBox VersionTextBox;
+        private MetroSetLabel ConvertSkinToZUpLabel;
+        private MetroSetCheckBox ConvertSkinToZUpCheckBox;
+        private MetroSetCheckBox GenerateVertexColorsCheckBox;
+        private MetroSetLabel GenerateVertexColorsLabel;
         private System.Windows.Forms.ToolTip descriptionTooltip;
         private System.Windows.Forms.Button OpenPresetButton;
-        private System.Windows.Forms.Label minVertexAttributesLabel;
-        private System.Windows.Forms.CheckBox MinimalVertexAttributesCheckBox;
+        private MetroSetLabel minVertexAttributesLabel;
+        private MetroSetCheckBox MinimalVertexAttributesCheckBox;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
+        private System.Windows.Forms.Button CancelButton;
+        private System.Windows.Forms.Button ConvertButton;
     }
 }

--- a/GFDStudio/GUI/Forms/ModelConverterOptionsDialog.cs
+++ b/GFDStudio/GUI/Forms/ModelConverterOptionsDialog.cs
@@ -6,16 +6,17 @@ using System.Diagnostics;
 using System.Linq;
 using GFDLibrary;
 using GFDLibrary.Materials;
+using MetroSet_UI.Forms;
 
 namespace GFDStudio.GUI.Forms
 {
-    public partial class ModelConverterOptionsDialog : Form
+    public partial class ModelConverterOptionsDialog : MetroSetForm
     {
 
         private static string PresetLibraryPath = System.IO.Path.GetDirectoryName( Application.ExecutablePath ) + @"\Presets\";
         private string[] Presets = Directory.GetFiles( PresetLibraryPath, "*.yml" ).Select( file => Path.GetFileName( file ) ).ToArray();
 
-        public object MaterialPreset 
+        public object MaterialPreset
             => YamlSerializer.LoadYamlFile<Material>( PresetLibraryPath + Presets[MaterialPresetComboBox.SelectedIndex] );
 
 

--- a/GFDStudio/GUI/Forms/ModelConverterOptionsDialog.resx
+++ b/GFDStudio/GUI/Forms/ModelConverterOptionsDialog.resx
@@ -1,4 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
 <root>
+  <!--
+    Microsoft ResX Schema 
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing"">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">

--- a/GFDStudio/GUI/Forms/SetScaleValueDialog.Designer.cs
+++ b/GFDStudio/GUI/Forms/SetScaleValueDialog.Designer.cs
@@ -1,6 +1,9 @@
-﻿namespace GFDStudio.GUI.Forms
+﻿using MetroSet_UI.Controls;
+using MetroSet_UI.Forms;
+
+namespace GFDStudio.GUI.Forms
 {
-    partial class SetScaleValueDialog
+    partial class SetScaleValueDialog : MetroSetForm
     {
         /// <summary>
         /// Required designer variable.
@@ -28,539 +31,669 @@
         /// </summary>
         private void InitializeComponent()
         {
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SetScaleValueDialog));
-            this.tableLayoutPanel_Scale = new System.Windows.Forms.TableLayoutPanel();
-            this.lbl_ScaleZ = new System.Windows.Forms.Label();
-            this.lbl_scaleX = new System.Windows.Forms.Label();
-            this.num_ScaleX = new System.Windows.Forms.NumericUpDown();
-            this.lbl_ScaleY = new System.Windows.Forms.Label();
-            this.num_ScaleY = new System.Windows.Forms.NumericUpDown();
-            this.num_ScaleZ = new System.Windows.Forms.NumericUpDown();
-            this.lbl_Scale = new System.Windows.Forms.Label();
-            this.CancelButton = new System.Windows.Forms.Button();
-            this.OKButton = new System.Windows.Forms.Button();
-            this.tableLayoutPanel_Pos = new System.Windows.Forms.TableLayoutPanel();
-            this.lbl_PosZ = new System.Windows.Forms.Label();
-            this.lbl_PosX = new System.Windows.Forms.Label();
-            this.num_PosX = new System.Windows.Forms.NumericUpDown();
-            this.lbl_PosY = new System.Windows.Forms.Label();
-            this.num_PosY = new System.Windows.Forms.NumericUpDown();
-            this.num_PosZ = new System.Windows.Forms.NumericUpDown();
-            this.lbl_Position = new System.Windows.Forms.Label();
-            this.tableLayoutPanel_Rot = new System.Windows.Forms.TableLayoutPanel();
-            this.lbl_RotW = new System.Windows.Forms.Label();
-            this.lbl_RotZ = new System.Windows.Forms.Label();
-            this.lbl_RotX = new System.Windows.Forms.Label();
-            this.num_RotX = new System.Windows.Forms.NumericUpDown();
-            this.lbl_RotY = new System.Windows.Forms.Label();
-            this.num_RotY = new System.Windows.Forms.NumericUpDown();
-            this.num_RotZ = new System.Windows.Forms.NumericUpDown();
-            this.lbl_Rotation = new System.Windows.Forms.Label();
-            this.num_RotW = new System.Windows.Forms.NumericUpDown();
-            this.tableLayoutPanel_Scale.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.num_ScaleX)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.num_ScaleY)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.num_ScaleZ)).BeginInit();
-            this.tableLayoutPanel_Pos.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.num_PosX)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.num_PosY)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.num_PosZ)).BeginInit();
-            this.tableLayoutPanel_Rot.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.num_RotX)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.num_RotY)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.num_RotZ)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.num_RotW)).BeginInit();
-            this.SuspendLayout();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager( typeof( SetScaleValueDialog ) );
+            tableLayoutPanel_Scale = new System.Windows.Forms.TableLayoutPanel();
+            lbl_ScaleZ = new MetroSetLabel();
+            lbl_scaleX = new MetroSetLabel();
+            num_ScaleX = new MetroSetNumeric();
+            lbl_ScaleY = new MetroSetLabel();
+            num_ScaleY = new MetroSetNumeric();
+            num_ScaleZ = new MetroSetNumeric();
+            lbl_Scale = new MetroSetLabel();
+            CancelButton = new System.Windows.Forms.Button();
+            OKButton = new System.Windows.Forms.Button();
+            tableLayoutPanel_Pos = new System.Windows.Forms.TableLayoutPanel();
+            lbl_PosZ = new MetroSetLabel();
+            lbl_PosX = new MetroSetLabel();
+            num_PosX = new MetroSetNumeric();
+            lbl_PosY = new MetroSetLabel();
+            num_PosY = new MetroSetNumeric();
+            num_PosZ = new MetroSetNumeric();
+            lbl_Position = new MetroSetLabel();
+            tableLayoutPanel_Rot = new System.Windows.Forms.TableLayoutPanel();
+            lbl_RotW = new MetroSetLabel();
+            lbl_RotZ = new MetroSetLabel();
+            lbl_RotX = new MetroSetLabel();
+            num_RotX = new MetroSetNumeric();
+            lbl_RotY = new MetroSetLabel();
+            num_RotY = new MetroSetNumeric();
+            num_RotZ = new MetroSetNumeric();
+            lbl_Rotation = new MetroSetLabel();
+            num_RotW = new MetroSetNumeric();
+            tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            tableLayoutPanel_Scale.SuspendLayout();
+            tableLayoutPanel_Pos.SuspendLayout();
+            tableLayoutPanel_Rot.SuspendLayout();
+            tableLayoutPanel1.SuspendLayout();
+            SuspendLayout();
             // 
             // tableLayoutPanel_Scale
             // 
-            this.tableLayoutPanel_Scale.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.tableLayoutPanel_Scale.ColumnCount = 2;
-            this.tableLayoutPanel_Scale.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 19.52663F));
-            this.tableLayoutPanel_Scale.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 80.47337F));
-            this.tableLayoutPanel_Scale.Controls.Add(this.lbl_ScaleZ, 0, 3);
-            this.tableLayoutPanel_Scale.Controls.Add(this.lbl_scaleX, 0, 1);
-            this.tableLayoutPanel_Scale.Controls.Add(this.num_ScaleX, 1, 1);
-            this.tableLayoutPanel_Scale.Controls.Add(this.lbl_ScaleY, 0, 2);
-            this.tableLayoutPanel_Scale.Controls.Add(this.num_ScaleY, 1, 2);
-            this.tableLayoutPanel_Scale.Controls.Add(this.num_ScaleZ, 1, 3);
-            this.tableLayoutPanel_Scale.Controls.Add(this.lbl_Scale, 1, 0);
-            this.tableLayoutPanel_Scale.Location = new System.Drawing.Point(16, 18);
-            this.tableLayoutPanel_Scale.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.tableLayoutPanel_Scale.Name = "tableLayoutPanel_Scale";
-            this.tableLayoutPanel_Scale.RowCount = 4;
-            this.tableLayoutPanel_Scale.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel_Scale.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel_Scale.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 43F));
-            this.tableLayoutPanel_Scale.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 37F));
-            this.tableLayoutPanel_Scale.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 31F));
-            this.tableLayoutPanel_Scale.Size = new System.Drawing.Size(111, 149);
-            this.tableLayoutPanel_Scale.TabIndex = 0;
+            tableLayoutPanel_Scale.ColumnCount = 2;
+            tableLayoutPanel_Scale.ColumnStyles.Add( new System.Windows.Forms.ColumnStyle( System.Windows.Forms.SizeType.Percent, 19.52663F ) );
+            tableLayoutPanel_Scale.ColumnStyles.Add( new System.Windows.Forms.ColumnStyle( System.Windows.Forms.SizeType.Percent, 80.47337F ) );
+            tableLayoutPanel_Scale.Controls.Add( lbl_ScaleZ, 0, 3 );
+            tableLayoutPanel_Scale.Controls.Add( lbl_scaleX, 0, 1 );
+            tableLayoutPanel_Scale.Controls.Add( num_ScaleX, 1, 1 );
+            tableLayoutPanel_Scale.Controls.Add( lbl_ScaleY, 0, 2 );
+            tableLayoutPanel_Scale.Controls.Add( num_ScaleY, 1, 2 );
+            tableLayoutPanel_Scale.Controls.Add( num_ScaleZ, 1, 3 );
+            tableLayoutPanel_Scale.Controls.Add( lbl_Scale, 1, 0 );
+            tableLayoutPanel_Scale.Dock = System.Windows.Forms.DockStyle.Fill;
+            tableLayoutPanel_Scale.Location = new System.Drawing.Point( 4, 5 );
+            tableLayoutPanel_Scale.Margin = new System.Windows.Forms.Padding( 4, 5, 4, 5 );
+            tableLayoutPanel_Scale.Name = "tableLayoutPanel_Scale";
+            tableLayoutPanel_Scale.RowCount = 5;
+            tableLayoutPanel_Scale.RowStyles.Add( new System.Windows.Forms.RowStyle( System.Windows.Forms.SizeType.Percent, 20F ) );
+            tableLayoutPanel_Scale.RowStyles.Add( new System.Windows.Forms.RowStyle( System.Windows.Forms.SizeType.Percent, 20F ) );
+            tableLayoutPanel_Scale.RowStyles.Add( new System.Windows.Forms.RowStyle( System.Windows.Forms.SizeType.Percent, 20F ) );
+            tableLayoutPanel_Scale.RowStyles.Add( new System.Windows.Forms.RowStyle( System.Windows.Forms.SizeType.Percent, 20F ) );
+            tableLayoutPanel_Scale.RowStyles.Add( new System.Windows.Forms.RowStyle( System.Windows.Forms.SizeType.Percent, 20F ) );
+            tableLayoutPanel_Scale.Size = new System.Drawing.Size( 224, 298 );
+            tableLayoutPanel_Scale.TabIndex = 0;
             // 
             // lbl_ScaleZ
             // 
-            this.lbl_ScaleZ.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.lbl_ScaleZ.AutoSize = true;
-            this.lbl_ScaleZ.Location = new System.Drawing.Point(4, 120);
-            this.lbl_ScaleZ.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lbl_ScaleZ.Name = "lbl_ScaleZ";
-            this.lbl_ScaleZ.Size = new System.Drawing.Size(13, 20);
-            this.lbl_ScaleZ.TabIndex = 8;
-            this.lbl_ScaleZ.Text = "Z";
+            lbl_ScaleZ.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            lbl_ScaleZ.AutoSize = true;
+            lbl_ScaleZ.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            lbl_ScaleZ.IsDerivedStyle = true;
+            lbl_ScaleZ.Location = new System.Drawing.Point( 21, 196 );
+            lbl_ScaleZ.Margin = new System.Windows.Forms.Padding( 4, 0, 4, 0 );
+            lbl_ScaleZ.Name = "lbl_ScaleZ";
+            lbl_ScaleZ.Size = new System.Drawing.Size( 18, 20 );
+            lbl_ScaleZ.Style = MetroSet_UI.Enums.Style.Dark;
+            lbl_ScaleZ.StyleManager = null;
+            lbl_ScaleZ.TabIndex = 8;
+            lbl_ScaleZ.Text = "Z";
+            lbl_ScaleZ.ThemeAuthor = "Narwin";
+            lbl_ScaleZ.ThemeName = "MetroDark";
             // 
             // lbl_scaleX
             // 
-            this.lbl_scaleX.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.lbl_scaleX.AutoSize = true;
-            this.lbl_scaleX.Location = new System.Drawing.Point(4, 41);
-            this.lbl_scaleX.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lbl_scaleX.Name = "lbl_scaleX";
-            this.lbl_scaleX.Size = new System.Drawing.Size(13, 20);
-            this.lbl_scaleX.TabIndex = 3;
-            this.lbl_scaleX.Text = "X";
+            lbl_scaleX.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            lbl_scaleX.AutoSize = true;
+            lbl_scaleX.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            lbl_scaleX.IsDerivedStyle = true;
+            lbl_scaleX.Location = new System.Drawing.Point( 19, 78 );
+            lbl_scaleX.Margin = new System.Windows.Forms.Padding( 4, 0, 4, 0 );
+            lbl_scaleX.Name = "lbl_scaleX";
+            lbl_scaleX.Size = new System.Drawing.Size( 20, 20 );
+            lbl_scaleX.Style = MetroSet_UI.Enums.Style.Dark;
+            lbl_scaleX.StyleManager = null;
+            lbl_scaleX.TabIndex = 3;
+            lbl_scaleX.Text = "X";
+            lbl_scaleX.ThemeAuthor = "Narwin";
+            lbl_scaleX.ThemeName = "MetroDark";
             // 
             // num_ScaleX
             // 
-            this.num_ScaleX.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.num_ScaleX.DecimalPlaces = 2;
-            this.num_ScaleX.Location = new System.Drawing.Point(25, 39);
-            this.num_ScaleX.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.num_ScaleX.Minimum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            -2147483648});
-            this.num_ScaleX.Name = "num_ScaleX";
-            this.num_ScaleX.Size = new System.Drawing.Size(70, 27);
-            this.num_ScaleX.TabIndex = 4;
-            this.num_ScaleX.Value = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
+            num_ScaleX.Anchor =   System.Windows.Forms.AnchorStyles.Left  |  System.Windows.Forms.AnchorStyles.Right  ;
+            num_ScaleX.BackColor = System.Drawing.Color.Transparent;
+            num_ScaleX.BackgroundColor = System.Drawing.Color.Empty;
+            num_ScaleX.BorderColor = System.Drawing.Color.FromArgb(   110  ,   110  ,   110   );
+            num_ScaleX.DisabledBackColor = System.Drawing.Color.FromArgb(   80  ,   80  ,   80   );
+            num_ScaleX.DisabledBorderColor = System.Drawing.Color.FromArgb(   109  ,   109  ,   109   );
+            num_ScaleX.DisabledForeColor = System.Drawing.Color.FromArgb(   109  ,   109  ,   109   );
+            num_ScaleX.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            num_ScaleX.IsDerivedStyle = true;
+            num_ScaleX.Location = new System.Drawing.Point( 47, 75 );
+            num_ScaleX.Margin = new System.Windows.Forms.Padding( 4, 5, 4, 5 );
+            num_ScaleX.Maximum = 100;
+            num_ScaleX.Minimum = 0;
+            num_ScaleX.Name = "num_ScaleX";
+            num_ScaleX.Size = new System.Drawing.Size( 173, 26 );
+            num_ScaleX.Style = MetroSet_UI.Enums.Style.Dark;
+            num_ScaleX.StyleManager = null;
+            num_ScaleX.SymbolsColor = System.Drawing.Color.FromArgb(   110  ,   110  ,   110   );
+            num_ScaleX.TabIndex = 4;
+            num_ScaleX.ThemeAuthor = "Narwin";
+            num_ScaleX.ThemeName = "MetroDark";
+            num_ScaleX.Value = 1;
             // 
             // lbl_ScaleY
             // 
-            this.lbl_ScaleY.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.lbl_ScaleY.AutoSize = true;
-            this.lbl_ScaleY.Location = new System.Drawing.Point(4, 79);
-            this.lbl_ScaleY.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lbl_ScaleY.Name = "lbl_ScaleY";
-            this.lbl_ScaleY.Size = new System.Drawing.Size(13, 20);
-            this.lbl_ScaleY.TabIndex = 6;
-            this.lbl_ScaleY.Text = "Y";
+            lbl_ScaleY.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            lbl_ScaleY.AutoSize = true;
+            lbl_ScaleY.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            lbl_ScaleY.IsDerivedStyle = true;
+            lbl_ScaleY.Location = new System.Drawing.Point( 20, 137 );
+            lbl_ScaleY.Margin = new System.Windows.Forms.Padding( 4, 0, 4, 0 );
+            lbl_ScaleY.Name = "lbl_ScaleY";
+            lbl_ScaleY.Size = new System.Drawing.Size( 19, 20 );
+            lbl_ScaleY.Style = MetroSet_UI.Enums.Style.Dark;
+            lbl_ScaleY.StyleManager = null;
+            lbl_ScaleY.TabIndex = 6;
+            lbl_ScaleY.Text = "Y";
+            lbl_ScaleY.ThemeAuthor = "Narwin";
+            lbl_ScaleY.ThemeName = "MetroDark";
             // 
             // num_ScaleY
             // 
-            this.num_ScaleY.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.num_ScaleY.DecimalPlaces = 2;
-            this.num_ScaleY.Location = new System.Drawing.Point(25, 76);
-            this.num_ScaleY.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.num_ScaleY.Minimum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            -2147483648});
-            this.num_ScaleY.Name = "num_ScaleY";
-            this.num_ScaleY.Size = new System.Drawing.Size(70, 27);
-            this.num_ScaleY.TabIndex = 7;
-            this.num_ScaleY.Value = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
+            num_ScaleY.Anchor =   System.Windows.Forms.AnchorStyles.Left  |  System.Windows.Forms.AnchorStyles.Right  ;
+            num_ScaleY.BackColor = System.Drawing.Color.Transparent;
+            num_ScaleY.BackgroundColor = System.Drawing.Color.Empty;
+            num_ScaleY.BorderColor = System.Drawing.Color.FromArgb(   110  ,   110  ,   110   );
+            num_ScaleY.DisabledBackColor = System.Drawing.Color.FromArgb(   80  ,   80  ,   80   );
+            num_ScaleY.DisabledBorderColor = System.Drawing.Color.FromArgb(   109  ,   109  ,   109   );
+            num_ScaleY.DisabledForeColor = System.Drawing.Color.FromArgb(   109  ,   109  ,   109   );
+            num_ScaleY.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            num_ScaleY.IsDerivedStyle = true;
+            num_ScaleY.Location = new System.Drawing.Point( 47, 134 );
+            num_ScaleY.Margin = new System.Windows.Forms.Padding( 4, 5, 4, 5 );
+            num_ScaleY.Maximum = 100;
+            num_ScaleY.Minimum = 0;
+            num_ScaleY.Name = "num_ScaleY";
+            num_ScaleY.Size = new System.Drawing.Size( 173, 26 );
+            num_ScaleY.Style = MetroSet_UI.Enums.Style.Dark;
+            num_ScaleY.StyleManager = null;
+            num_ScaleY.SymbolsColor = System.Drawing.Color.FromArgb(   110  ,   110  ,   110   );
+            num_ScaleY.TabIndex = 7;
+            num_ScaleY.ThemeAuthor = "Narwin";
+            num_ScaleY.ThemeName = "MetroDark";
+            num_ScaleY.Value = 1;
             // 
             // num_ScaleZ
             // 
-            this.num_ScaleZ.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.num_ScaleZ.DecimalPlaces = 2;
-            this.num_ScaleZ.Location = new System.Drawing.Point(25, 116);
-            this.num_ScaleZ.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.num_ScaleZ.Minimum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            -2147483648});
-            this.num_ScaleZ.Name = "num_ScaleZ";
-            this.num_ScaleZ.Size = new System.Drawing.Size(70, 27);
-            this.num_ScaleZ.TabIndex = 9;
-            this.num_ScaleZ.Value = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
+            num_ScaleZ.Anchor =   System.Windows.Forms.AnchorStyles.Left  |  System.Windows.Forms.AnchorStyles.Right  ;
+            num_ScaleZ.BackColor = System.Drawing.Color.Transparent;
+            num_ScaleZ.BackgroundColor = System.Drawing.Color.Empty;
+            num_ScaleZ.BorderColor = System.Drawing.Color.FromArgb(   110  ,   110  ,   110   );
+            num_ScaleZ.DisabledBackColor = System.Drawing.Color.FromArgb(   80  ,   80  ,   80   );
+            num_ScaleZ.DisabledBorderColor = System.Drawing.Color.FromArgb(   109  ,   109  ,   109   );
+            num_ScaleZ.DisabledForeColor = System.Drawing.Color.FromArgb(   109  ,   109  ,   109   );
+            num_ScaleZ.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            num_ScaleZ.IsDerivedStyle = true;
+            num_ScaleZ.Location = new System.Drawing.Point( 47, 193 );
+            num_ScaleZ.Margin = new System.Windows.Forms.Padding( 4, 5, 4, 5 );
+            num_ScaleZ.Maximum = 100;
+            num_ScaleZ.Minimum = 0;
+            num_ScaleZ.Name = "num_ScaleZ";
+            num_ScaleZ.Size = new System.Drawing.Size( 173, 26 );
+            num_ScaleZ.Style = MetroSet_UI.Enums.Style.Dark;
+            num_ScaleZ.StyleManager = null;
+            num_ScaleZ.SymbolsColor = System.Drawing.Color.FromArgb(   110  ,   110  ,   110   );
+            num_ScaleZ.TabIndex = 9;
+            num_ScaleZ.ThemeAuthor = "Narwin";
+            num_ScaleZ.ThemeName = "MetroDark";
+            num_ScaleZ.Value = 1;
             // 
             // lbl_Scale
             // 
-            this.lbl_Scale.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.lbl_Scale.AutoSize = true;
-            this.lbl_Scale.Location = new System.Drawing.Point(34, 0);
-            this.lbl_Scale.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lbl_Scale.Name = "lbl_Scale";
-            this.lbl_Scale.Size = new System.Drawing.Size(73, 34);
-            this.lbl_Scale.TabIndex = 5;
-            this.lbl_Scale.Text = "Scale Multiplier";
+            lbl_Scale.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            lbl_Scale.AutoSize = true;
+            lbl_Scale.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            lbl_Scale.IsDerivedStyle = true;
+            lbl_Scale.Location = new System.Drawing.Point( 169, 19 );
+            lbl_Scale.Margin = new System.Windows.Forms.Padding( 4, 0, 4, 0 );
+            lbl_Scale.Name = "lbl_Scale";
+            lbl_Scale.Size = new System.Drawing.Size( 51, 20 );
+            lbl_Scale.Style = MetroSet_UI.Enums.Style.Dark;
+            lbl_Scale.StyleManager = null;
+            lbl_Scale.TabIndex = 5;
+            lbl_Scale.Text = "Scale";
+            lbl_Scale.ThemeAuthor = "Narwin";
+            lbl_Scale.ThemeName = "MetroDark";
             // 
             // CancelButton
             // 
-            this.CancelButton.Anchor = System.Windows.Forms.AnchorStyles.None;
-            this.CancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.CancelButton.Location = new System.Drawing.Point(20, 183);
-            this.CancelButton.Margin = new System.Windows.Forms.Padding(13, 15, 13, 15);
-            this.CancelButton.Name = "CancelButton";
-            this.CancelButton.Size = new System.Drawing.Size(100, 35);
-            this.CancelButton.TabIndex = 1;
-            this.CancelButton.Text = "Cancel";
-            this.CancelButton.UseVisualStyleBackColor = true;
+            CancelButton.Anchor = System.Windows.Forms.AnchorStyles.None;
+            CancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            CancelButton.ForeColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            CancelButton.Location = new System.Drawing.Point( 275, 323 );
+            CancelButton.Margin = new System.Windows.Forms.Padding( 13, 15, 13, 15 );
+            CancelButton.Name = "CancelButton";
+            CancelButton.Size = new System.Drawing.Size( 146, 47 );
+            CancelButton.TabIndex = 1;
+            CancelButton.Text = "Cancel";
+            CancelButton.UseVisualStyleBackColor = true;
             // 
             // OKButton
             // 
-            this.OKButton.Anchor = System.Windows.Forms.AnchorStyles.None;
-            this.OKButton.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.OKButton.Location = new System.Drawing.Point(139, 183);
-            this.OKButton.Margin = new System.Windows.Forms.Padding(13, 15, 13, 15);
-            this.OKButton.Name = "OKButton";
-            this.OKButton.Size = new System.Drawing.Size(100, 35);
-            this.OKButton.TabIndex = 2;
-            this.OKButton.Text = "OK";
-            this.OKButton.UseVisualStyleBackColor = true;
-            this.OKButton.Click += new System.EventHandler(this.OKButton_Click);
+            OKButton.Anchor = System.Windows.Forms.AnchorStyles.None;
+            OKButton.DialogResult = System.Windows.Forms.DialogResult.OK;
+            OKButton.ForeColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            OKButton.Location = new System.Drawing.Point( 523, 323 );
+            OKButton.Margin = new System.Windows.Forms.Padding( 13, 15, 13, 15 );
+            OKButton.Name = "OKButton";
+            OKButton.Size = new System.Drawing.Size( 114, 47 );
+            OKButton.TabIndex = 2;
+            OKButton.Text = "OK";
+            OKButton.UseVisualStyleBackColor = true;
+            OKButton.Click += OKButton_Click;
             // 
             // tableLayoutPanel_Pos
             // 
-            this.tableLayoutPanel_Pos.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.tableLayoutPanel_Pos.ColumnCount = 2;
-            this.tableLayoutPanel_Pos.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 27.02703F));
-            this.tableLayoutPanel_Pos.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 72.97298F));
-            this.tableLayoutPanel_Pos.Controls.Add(this.lbl_PosZ, 0, 3);
-            this.tableLayoutPanel_Pos.Controls.Add(this.lbl_PosX, 0, 1);
-            this.tableLayoutPanel_Pos.Controls.Add(this.num_PosX, 1, 1);
-            this.tableLayoutPanel_Pos.Controls.Add(this.lbl_PosY, 0, 2);
-            this.tableLayoutPanel_Pos.Controls.Add(this.num_PosY, 1, 2);
-            this.tableLayoutPanel_Pos.Controls.Add(this.num_PosZ, 1, 3);
-            this.tableLayoutPanel_Pos.Controls.Add(this.lbl_Position, 1, 0);
-            this.tableLayoutPanel_Pos.Location = new System.Drawing.Point(135, 20);
-            this.tableLayoutPanel_Pos.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.tableLayoutPanel_Pos.Name = "tableLayoutPanel_Pos";
-            this.tableLayoutPanel_Pos.RowCount = 4;
-            this.tableLayoutPanel_Pos.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 47.05882F));
-            this.tableLayoutPanel_Pos.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 52.94118F));
-            this.tableLayoutPanel_Pos.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 43F));
-            this.tableLayoutPanel_Pos.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 37F));
-            this.tableLayoutPanel_Pos.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 31F));
-            this.tableLayoutPanel_Pos.Size = new System.Drawing.Size(111, 149);
-            this.tableLayoutPanel_Pos.TabIndex = 3;
+            tableLayoutPanel_Pos.ColumnCount = 2;
+            tableLayoutPanel_Pos.ColumnStyles.Add( new System.Windows.Forms.ColumnStyle( System.Windows.Forms.SizeType.Percent, 27.027029F ) );
+            tableLayoutPanel_Pos.ColumnStyles.Add( new System.Windows.Forms.ColumnStyle( System.Windows.Forms.SizeType.Percent, 72.97298F ) );
+            tableLayoutPanel_Pos.Controls.Add( lbl_PosZ, 0, 3 );
+            tableLayoutPanel_Pos.Controls.Add( lbl_PosX, 0, 1 );
+            tableLayoutPanel_Pos.Controls.Add( num_PosX, 1, 1 );
+            tableLayoutPanel_Pos.Controls.Add( lbl_PosY, 0, 2 );
+            tableLayoutPanel_Pos.Controls.Add( num_PosY, 1, 2 );
+            tableLayoutPanel_Pos.Controls.Add( num_PosZ, 1, 3 );
+            tableLayoutPanel_Pos.Controls.Add( lbl_Position, 1, 0 );
+            tableLayoutPanel_Pos.Dock = System.Windows.Forms.DockStyle.Fill;
+            tableLayoutPanel_Pos.Location = new System.Drawing.Point( 468, 5 );
+            tableLayoutPanel_Pos.Margin = new System.Windows.Forms.Padding( 4, 5, 4, 5 );
+            tableLayoutPanel_Pos.Name = "tableLayoutPanel_Pos";
+            tableLayoutPanel_Pos.RowCount = 5;
+            tableLayoutPanel_Pos.RowStyles.Add( new System.Windows.Forms.RowStyle( System.Windows.Forms.SizeType.Percent, 20F ) );
+            tableLayoutPanel_Pos.RowStyles.Add( new System.Windows.Forms.RowStyle( System.Windows.Forms.SizeType.Percent, 20F ) );
+            tableLayoutPanel_Pos.RowStyles.Add( new System.Windows.Forms.RowStyle( System.Windows.Forms.SizeType.Percent, 20F ) );
+            tableLayoutPanel_Pos.RowStyles.Add( new System.Windows.Forms.RowStyle( System.Windows.Forms.SizeType.Percent, 20F ) );
+            tableLayoutPanel_Pos.RowStyles.Add( new System.Windows.Forms.RowStyle( System.Windows.Forms.SizeType.Percent, 20F ) );
+            tableLayoutPanel_Pos.Size = new System.Drawing.Size( 224, 298 );
+            tableLayoutPanel_Pos.TabIndex = 3;
             // 
             // lbl_PosZ
             // 
-            this.lbl_PosZ.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.lbl_PosZ.AutoSize = true;
-            this.lbl_PosZ.Location = new System.Drawing.Point(8, 120);
-            this.lbl_PosZ.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lbl_PosZ.Name = "lbl_PosZ";
-            this.lbl_PosZ.Size = new System.Drawing.Size(18, 20);
-            this.lbl_PosZ.TabIndex = 8;
-            this.lbl_PosZ.Text = "Z";
+            lbl_PosZ.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            lbl_PosZ.AutoSize = true;
+            lbl_PosZ.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            lbl_PosZ.IsDerivedStyle = true;
+            lbl_PosZ.Location = new System.Drawing.Point( 38, 196 );
+            lbl_PosZ.Margin = new System.Windows.Forms.Padding( 4, 0, 4, 0 );
+            lbl_PosZ.Name = "lbl_PosZ";
+            lbl_PosZ.Size = new System.Drawing.Size( 18, 20 );
+            lbl_PosZ.Style = MetroSet_UI.Enums.Style.Dark;
+            lbl_PosZ.StyleManager = null;
+            lbl_PosZ.TabIndex = 8;
+            lbl_PosZ.Text = "Z";
+            lbl_PosZ.ThemeAuthor = "Narwin";
+            lbl_PosZ.ThemeName = "MetroDark";
             // 
             // lbl_PosX
             // 
-            this.lbl_PosX.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.lbl_PosX.AutoSize = true;
-            this.lbl_PosX.Location = new System.Drawing.Point(8, 40);
-            this.lbl_PosX.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lbl_PosX.Name = "lbl_PosX";
-            this.lbl_PosX.Size = new System.Drawing.Size(18, 20);
-            this.lbl_PosX.TabIndex = 3;
-            this.lbl_PosX.Text = "X";
+            lbl_PosX.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            lbl_PosX.AutoSize = true;
+            lbl_PosX.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            lbl_PosX.IsDerivedStyle = true;
+            lbl_PosX.Location = new System.Drawing.Point( 36, 78 );
+            lbl_PosX.Margin = new System.Windows.Forms.Padding( 4, 0, 4, 0 );
+            lbl_PosX.Name = "lbl_PosX";
+            lbl_PosX.Size = new System.Drawing.Size( 20, 20 );
+            lbl_PosX.Style = MetroSet_UI.Enums.Style.Dark;
+            lbl_PosX.StyleManager = null;
+            lbl_PosX.TabIndex = 3;
+            lbl_PosX.Text = "X";
+            lbl_PosX.ThemeAuthor = "Narwin";
+            lbl_PosX.ThemeName = "MetroDark";
             // 
             // num_PosX
             // 
-            this.num_PosX.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.num_PosX.DecimalPlaces = 2;
-            this.num_PosX.Location = new System.Drawing.Point(34, 37);
-            this.num_PosX.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.num_PosX.Maximum = new decimal(new int[] {
-            999,
-            0,
-            0,
-            0});
-            this.num_PosX.Minimum = new decimal(new int[] {
-            999,
-            0,
-            0,
-            -2147483648});
-            this.num_PosX.Name = "num_PosX";
-            this.num_PosX.Size = new System.Drawing.Size(70, 27);
-            this.num_PosX.TabIndex = 4;
+            num_PosX.Anchor =   System.Windows.Forms.AnchorStyles.Left  |  System.Windows.Forms.AnchorStyles.Right  ;
+            num_PosX.BackColor = System.Drawing.Color.Transparent;
+            num_PosX.BackgroundColor = System.Drawing.Color.Empty;
+            num_PosX.BorderColor = System.Drawing.Color.FromArgb(   110  ,   110  ,   110   );
+            num_PosX.DisabledBackColor = System.Drawing.Color.FromArgb(   80  ,   80  ,   80   );
+            num_PosX.DisabledBorderColor = System.Drawing.Color.FromArgb(   109  ,   109  ,   109   );
+            num_PosX.DisabledForeColor = System.Drawing.Color.FromArgb(   109  ,   109  ,   109   );
+            num_PosX.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            num_PosX.IsDerivedStyle = true;
+            num_PosX.Location = new System.Drawing.Point( 64, 75 );
+            num_PosX.Margin = new System.Windows.Forms.Padding( 4, 5, 4, 5 );
+            num_PosX.Maximum = 999999;
+            num_PosX.Minimum = -999999;
+            num_PosX.Name = "num_PosX";
+            num_PosX.Size = new System.Drawing.Size( 156, 26 );
+            num_PosX.Style = MetroSet_UI.Enums.Style.Dark;
+            num_PosX.StyleManager = null;
+            num_PosX.SymbolsColor = System.Drawing.Color.FromArgb(   110  ,   110  ,   110   );
+            num_PosX.TabIndex = 4;
+            num_PosX.ThemeAuthor = "Narwin";
+            num_PosX.ThemeName = "MetroDark";
+            num_PosX.Value = 0;
             // 
             // lbl_PosY
             // 
-            this.lbl_PosY.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.lbl_PosY.AutoSize = true;
-            this.lbl_PosY.Location = new System.Drawing.Point(9, 79);
-            this.lbl_PosY.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lbl_PosY.Name = "lbl_PosY";
-            this.lbl_PosY.Size = new System.Drawing.Size(17, 20);
-            this.lbl_PosY.TabIndex = 6;
-            this.lbl_PosY.Text = "Y";
+            lbl_PosY.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            lbl_PosY.AutoSize = true;
+            lbl_PosY.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            lbl_PosY.IsDerivedStyle = true;
+            lbl_PosY.Location = new System.Drawing.Point( 37, 137 );
+            lbl_PosY.Margin = new System.Windows.Forms.Padding( 4, 0, 4, 0 );
+            lbl_PosY.Name = "lbl_PosY";
+            lbl_PosY.Size = new System.Drawing.Size( 19, 20 );
+            lbl_PosY.Style = MetroSet_UI.Enums.Style.Dark;
+            lbl_PosY.StyleManager = null;
+            lbl_PosY.TabIndex = 6;
+            lbl_PosY.Text = "Y";
+            lbl_PosY.ThemeAuthor = "Narwin";
+            lbl_PosY.ThemeName = "MetroDark";
             // 
             // num_PosY
             // 
-            this.num_PosY.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.num_PosY.DecimalPlaces = 2;
-            this.num_PosY.Location = new System.Drawing.Point(34, 76);
-            this.num_PosY.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.num_PosY.Maximum = new decimal(new int[] {
-            999,
-            0,
-            0,
-            0});
-            this.num_PosY.Minimum = new decimal(new int[] {
-            999,
-            0,
-            0,
-            -2147483648});
-            this.num_PosY.Name = "num_PosY";
-            this.num_PosY.Size = new System.Drawing.Size(70, 27);
-            this.num_PosY.TabIndex = 7;
+            num_PosY.Anchor =   System.Windows.Forms.AnchorStyles.Left  |  System.Windows.Forms.AnchorStyles.Right  ;
+            num_PosY.BackColor = System.Drawing.Color.Transparent;
+            num_PosY.BackgroundColor = System.Drawing.Color.Empty;
+            num_PosY.BorderColor = System.Drawing.Color.FromArgb(   110  ,   110  ,   110   );
+            num_PosY.DisabledBackColor = System.Drawing.Color.FromArgb(   80  ,   80  ,   80   );
+            num_PosY.DisabledBorderColor = System.Drawing.Color.FromArgb(   109  ,   109  ,   109   );
+            num_PosY.DisabledForeColor = System.Drawing.Color.FromArgb(   109  ,   109  ,   109   );
+            num_PosY.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            num_PosY.IsDerivedStyle = true;
+            num_PosY.Location = new System.Drawing.Point( 64, 134 );
+            num_PosY.Margin = new System.Windows.Forms.Padding( 4, 5, 4, 5 );
+            num_PosY.Maximum = 999999;
+            num_PosY.Minimum = -999999;
+            num_PosY.Name = "num_PosY";
+            num_PosY.Size = new System.Drawing.Size( 156, 26 );
+            num_PosY.Style = MetroSet_UI.Enums.Style.Dark;
+            num_PosY.StyleManager = null;
+            num_PosY.SymbolsColor = System.Drawing.Color.FromArgb(   110  ,   110  ,   110   );
+            num_PosY.TabIndex = 7;
+            num_PosY.ThemeAuthor = "Narwin";
+            num_PosY.ThemeName = "MetroDark";
+            num_PosY.Value = 0;
             // 
             // num_PosZ
             // 
-            this.num_PosZ.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.num_PosZ.DecimalPlaces = 2;
-            this.num_PosZ.Location = new System.Drawing.Point(34, 116);
-            this.num_PosZ.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.num_PosZ.Maximum = new decimal(new int[] {
-            999,
-            0,
-            0,
-            0});
-            this.num_PosZ.Minimum = new decimal(new int[] {
-            999,
-            0,
-            0,
-            -2147483648});
-            this.num_PosZ.Name = "num_PosZ";
-            this.num_PosZ.Size = new System.Drawing.Size(70, 27);
-            this.num_PosZ.TabIndex = 9;
+            num_PosZ.Anchor =   System.Windows.Forms.AnchorStyles.Left  |  System.Windows.Forms.AnchorStyles.Right  ;
+            num_PosZ.BackColor = System.Drawing.Color.Transparent;
+            num_PosZ.BackgroundColor = System.Drawing.Color.Empty;
+            num_PosZ.BorderColor = System.Drawing.Color.FromArgb(   110  ,   110  ,   110   );
+            num_PosZ.DisabledBackColor = System.Drawing.Color.FromArgb(   80  ,   80  ,   80   );
+            num_PosZ.DisabledBorderColor = System.Drawing.Color.FromArgb(   109  ,   109  ,   109   );
+            num_PosZ.DisabledForeColor = System.Drawing.Color.FromArgb(   109  ,   109  ,   109   );
+            num_PosZ.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            num_PosZ.IsDerivedStyle = true;
+            num_PosZ.Location = new System.Drawing.Point( 64, 193 );
+            num_PosZ.Margin = new System.Windows.Forms.Padding( 4, 5, 4, 5 );
+            num_PosZ.Maximum = 999999;
+            num_PosZ.Minimum = -999999;
+            num_PosZ.Name = "num_PosZ";
+            num_PosZ.Size = new System.Drawing.Size( 156, 26 );
+            num_PosZ.Style = MetroSet_UI.Enums.Style.Dark;
+            num_PosZ.StyleManager = null;
+            num_PosZ.SymbolsColor = System.Drawing.Color.FromArgb(   110  ,   110  ,   110   );
+            num_PosZ.TabIndex = 9;
+            num_PosZ.ThemeAuthor = "Narwin";
+            num_PosZ.ThemeName = "MetroDark";
+            num_PosZ.Value = 0;
             // 
             // lbl_Position
             // 
-            this.lbl_Position.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.lbl_Position.AutoSize = true;
-            this.lbl_Position.Location = new System.Drawing.Point(42, 0);
-            this.lbl_Position.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lbl_Position.Name = "lbl_Position";
-            this.lbl_Position.Size = new System.Drawing.Size(65, 32);
-            this.lbl_Position.TabIndex = 5;
-            this.lbl_Position.Text = "Position Offset";
+            lbl_Position.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            lbl_Position.AutoSize = true;
+            lbl_Position.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            lbl_Position.IsDerivedStyle = true;
+            lbl_Position.Location = new System.Drawing.Point( 151, 19 );
+            lbl_Position.Margin = new System.Windows.Forms.Padding( 4, 0, 4, 0 );
+            lbl_Position.Name = "lbl_Position";
+            lbl_Position.Size = new System.Drawing.Size( 69, 20 );
+            lbl_Position.Style = MetroSet_UI.Enums.Style.Dark;
+            lbl_Position.StyleManager = null;
+            lbl_Position.TabIndex = 5;
+            lbl_Position.Text = "Position";
+            lbl_Position.ThemeAuthor = "Narwin";
+            lbl_Position.ThemeName = "MetroDark";
             // 
             // tableLayoutPanel_Rot
             // 
-            this.tableLayoutPanel_Rot.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.tableLayoutPanel_Rot.ColumnCount = 2;
-            this.tableLayoutPanel_Rot.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 25.71428F));
-            this.tableLayoutPanel_Rot.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 74.28571F));
-            this.tableLayoutPanel_Rot.Controls.Add(this.lbl_RotW, 0, 4);
-            this.tableLayoutPanel_Rot.Controls.Add(this.lbl_RotZ, 0, 3);
-            this.tableLayoutPanel_Rot.Controls.Add(this.lbl_RotX, 0, 1);
-            this.tableLayoutPanel_Rot.Controls.Add(this.num_RotX, 1, 1);
-            this.tableLayoutPanel_Rot.Controls.Add(this.lbl_RotY, 0, 2);
-            this.tableLayoutPanel_Rot.Controls.Add(this.num_RotY, 1, 2);
-            this.tableLayoutPanel_Rot.Controls.Add(this.num_RotZ, 1, 3);
-            this.tableLayoutPanel_Rot.Controls.Add(this.lbl_Rotation, 1, 0);
-            this.tableLayoutPanel_Rot.Controls.Add(this.num_RotW, 1, 4);
-            this.tableLayoutPanel_Rot.Location = new System.Drawing.Point(254, 20);
-            this.tableLayoutPanel_Rot.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.tableLayoutPanel_Rot.Name = "tableLayoutPanel_Rot";
-            this.tableLayoutPanel_Rot.RowCount = 5;
-            this.tableLayoutPanel_Rot.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 45.71429F));
-            this.tableLayoutPanel_Rot.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 54.28571F));
-            this.tableLayoutPanel_Rot.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 44F));
-            this.tableLayoutPanel_Rot.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 35F));
-            this.tableLayoutPanel_Rot.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 38F));
-            this.tableLayoutPanel_Rot.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 31F));
-            this.tableLayoutPanel_Rot.Size = new System.Drawing.Size(131, 186);
-            this.tableLayoutPanel_Rot.TabIndex = 10;
+            tableLayoutPanel_Rot.ColumnCount = 2;
+            tableLayoutPanel_Rot.ColumnStyles.Add( new System.Windows.Forms.ColumnStyle( System.Windows.Forms.SizeType.Percent, 25.7142811F ) );
+            tableLayoutPanel_Rot.ColumnStyles.Add( new System.Windows.Forms.ColumnStyle( System.Windows.Forms.SizeType.Percent, 74.28572F ) );
+            tableLayoutPanel_Rot.Controls.Add( lbl_RotW, 0, 4 );
+            tableLayoutPanel_Rot.Controls.Add( lbl_RotZ, 0, 3 );
+            tableLayoutPanel_Rot.Controls.Add( lbl_RotX, 0, 1 );
+            tableLayoutPanel_Rot.Controls.Add( num_RotX, 1, 1 );
+            tableLayoutPanel_Rot.Controls.Add( lbl_RotY, 0, 2 );
+            tableLayoutPanel_Rot.Controls.Add( num_RotY, 1, 2 );
+            tableLayoutPanel_Rot.Controls.Add( num_RotZ, 1, 3 );
+            tableLayoutPanel_Rot.Controls.Add( lbl_Rotation, 1, 0 );
+            tableLayoutPanel_Rot.Controls.Add( num_RotW, 1, 4 );
+            tableLayoutPanel_Rot.Dock = System.Windows.Forms.DockStyle.Fill;
+            tableLayoutPanel_Rot.Location = new System.Drawing.Point( 236, 5 );
+            tableLayoutPanel_Rot.Margin = new System.Windows.Forms.Padding( 4, 5, 4, 5 );
+            tableLayoutPanel_Rot.Name = "tableLayoutPanel_Rot";
+            tableLayoutPanel_Rot.RowCount = 5;
+            tableLayoutPanel_Rot.RowStyles.Add( new System.Windows.Forms.RowStyle( System.Windows.Forms.SizeType.Percent, 20F ) );
+            tableLayoutPanel_Rot.RowStyles.Add( new System.Windows.Forms.RowStyle( System.Windows.Forms.SizeType.Percent, 20F ) );
+            tableLayoutPanel_Rot.RowStyles.Add( new System.Windows.Forms.RowStyle( System.Windows.Forms.SizeType.Percent, 20F ) );
+            tableLayoutPanel_Rot.RowStyles.Add( new System.Windows.Forms.RowStyle( System.Windows.Forms.SizeType.Percent, 20F ) );
+            tableLayoutPanel_Rot.RowStyles.Add( new System.Windows.Forms.RowStyle( System.Windows.Forms.SizeType.Percent, 20F ) );
+            tableLayoutPanel_Rot.Size = new System.Drawing.Size( 224, 298 );
+            tableLayoutPanel_Rot.TabIndex = 10;
             // 
             // lbl_RotW
             // 
-            this.lbl_RotW.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.lbl_RotW.AutoSize = true;
-            this.lbl_RotW.Location = new System.Drawing.Point(6, 156);
-            this.lbl_RotW.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lbl_RotW.Name = "lbl_RotW";
-            this.lbl_RotW.Size = new System.Drawing.Size(23, 20);
-            this.lbl_RotW.TabIndex = 10;
-            this.lbl_RotW.Text = "W";
+            lbl_RotW.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            lbl_RotW.AutoSize = true;
+            lbl_RotW.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            lbl_RotW.IsDerivedStyle = true;
+            lbl_RotW.Location = new System.Drawing.Point( 28, 257 );
+            lbl_RotW.Margin = new System.Windows.Forms.Padding( 4, 0, 4, 0 );
+            lbl_RotW.Name = "lbl_RotW";
+            lbl_RotW.Size = new System.Drawing.Size( 25, 20 );
+            lbl_RotW.Style = MetroSet_UI.Enums.Style.Dark;
+            lbl_RotW.StyleManager = null;
+            lbl_RotW.TabIndex = 10;
+            lbl_RotW.Text = "W";
+            lbl_RotW.ThemeAuthor = "Narwin";
+            lbl_RotW.ThemeName = "MetroDark";
             // 
             // lbl_RotZ
             // 
-            this.lbl_RotZ.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.lbl_RotZ.AutoSize = true;
-            this.lbl_RotZ.Location = new System.Drawing.Point(11, 119);
-            this.lbl_RotZ.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lbl_RotZ.Name = "lbl_RotZ";
-            this.lbl_RotZ.Size = new System.Drawing.Size(18, 20);
-            this.lbl_RotZ.TabIndex = 8;
-            this.lbl_RotZ.Text = "Z";
+            lbl_RotZ.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            lbl_RotZ.AutoSize = true;
+            lbl_RotZ.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            lbl_RotZ.IsDerivedStyle = true;
+            lbl_RotZ.Location = new System.Drawing.Point( 35, 196 );
+            lbl_RotZ.Margin = new System.Windows.Forms.Padding( 4, 0, 4, 0 );
+            lbl_RotZ.Name = "lbl_RotZ";
+            lbl_RotZ.Size = new System.Drawing.Size( 18, 20 );
+            lbl_RotZ.Style = MetroSet_UI.Enums.Style.Dark;
+            lbl_RotZ.StyleManager = null;
+            lbl_RotZ.TabIndex = 8;
+            lbl_RotZ.Text = "Z";
+            lbl_RotZ.ThemeAuthor = "Narwin";
+            lbl_RotZ.ThemeName = "MetroDark";
             // 
             // lbl_RotX
             // 
-            this.lbl_RotX.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.lbl_RotX.AutoSize = true;
-            this.lbl_RotX.Location = new System.Drawing.Point(11, 39);
-            this.lbl_RotX.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lbl_RotX.Name = "lbl_RotX";
-            this.lbl_RotX.Size = new System.Drawing.Size(18, 20);
-            this.lbl_RotX.TabIndex = 3;
-            this.lbl_RotX.Text = "X";
+            lbl_RotX.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            lbl_RotX.AutoSize = true;
+            lbl_RotX.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            lbl_RotX.IsDerivedStyle = true;
+            lbl_RotX.Location = new System.Drawing.Point( 33, 78 );
+            lbl_RotX.Margin = new System.Windows.Forms.Padding( 4, 0, 4, 0 );
+            lbl_RotX.Name = "lbl_RotX";
+            lbl_RotX.Size = new System.Drawing.Size( 20, 20 );
+            lbl_RotX.Style = MetroSet_UI.Enums.Style.Dark;
+            lbl_RotX.StyleManager = null;
+            lbl_RotX.TabIndex = 3;
+            lbl_RotX.Text = "X";
+            lbl_RotX.ThemeAuthor = "Narwin";
+            lbl_RotX.ThemeName = "MetroDark";
             // 
             // num_RotX
             // 
-            this.num_RotX.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.num_RotX.DecimalPlaces = 7;
-            this.num_RotX.Location = new System.Drawing.Point(37, 36);
-            this.num_RotX.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.num_RotX.Maximum = new decimal(new int[] {
-            999,
-            0,
-            0,
-            0});
-            this.num_RotX.Minimum = new decimal(new int[] {
-            999,
-            0,
-            0,
-            -2147483648});
-            this.num_RotX.Name = "num_RotX";
-            this.num_RotX.Size = new System.Drawing.Size(90, 27);
-            this.num_RotX.TabIndex = 4;
+            num_RotX.Anchor =   System.Windows.Forms.AnchorStyles.Left  |  System.Windows.Forms.AnchorStyles.Right  ;
+            num_RotX.BackColor = System.Drawing.Color.Transparent;
+            num_RotX.BackgroundColor = System.Drawing.Color.Empty;
+            num_RotX.BorderColor = System.Drawing.Color.FromArgb(   110  ,   110  ,   110   );
+            num_RotX.DisabledBackColor = System.Drawing.Color.FromArgb(   80  ,   80  ,   80   );
+            num_RotX.DisabledBorderColor = System.Drawing.Color.FromArgb(   109  ,   109  ,   109   );
+            num_RotX.DisabledForeColor = System.Drawing.Color.FromArgb(   109  ,   109  ,   109   );
+            num_RotX.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            num_RotX.IsDerivedStyle = true;
+            num_RotX.Location = new System.Drawing.Point( 61, 75 );
+            num_RotX.Margin = new System.Windows.Forms.Padding( 4, 5, 4, 5 );
+            num_RotX.Maximum = 999;
+            num_RotX.Minimum = -999;
+            num_RotX.Name = "num_RotX";
+            num_RotX.Size = new System.Drawing.Size( 159, 26 );
+            num_RotX.Style = MetroSet_UI.Enums.Style.Dark;
+            num_RotX.StyleManager = null;
+            num_RotX.SymbolsColor = System.Drawing.Color.FromArgb(   110  ,   110  ,   110   );
+            num_RotX.TabIndex = 4;
+            num_RotX.ThemeAuthor = "Narwin";
+            num_RotX.ThemeName = "MetroDark";
+            num_RotX.Value = 0;
             // 
             // lbl_RotY
             // 
-            this.lbl_RotY.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.lbl_RotY.AutoSize = true;
-            this.lbl_RotY.Location = new System.Drawing.Point(12, 80);
-            this.lbl_RotY.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lbl_RotY.Name = "lbl_RotY";
-            this.lbl_RotY.Size = new System.Drawing.Size(17, 20);
-            this.lbl_RotY.TabIndex = 6;
-            this.lbl_RotY.Text = "Y";
+            lbl_RotY.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            lbl_RotY.AutoSize = true;
+            lbl_RotY.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            lbl_RotY.IsDerivedStyle = true;
+            lbl_RotY.Location = new System.Drawing.Point( 34, 137 );
+            lbl_RotY.Margin = new System.Windows.Forms.Padding( 4, 0, 4, 0 );
+            lbl_RotY.Name = "lbl_RotY";
+            lbl_RotY.Size = new System.Drawing.Size( 19, 20 );
+            lbl_RotY.Style = MetroSet_UI.Enums.Style.Dark;
+            lbl_RotY.StyleManager = null;
+            lbl_RotY.TabIndex = 6;
+            lbl_RotY.Text = "Y";
+            lbl_RotY.ThemeAuthor = "Narwin";
+            lbl_RotY.ThemeName = "MetroDark";
             // 
             // num_RotY
             // 
-            this.num_RotY.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.num_RotY.DecimalPlaces = 7;
-            this.num_RotY.Location = new System.Drawing.Point(37, 76);
-            this.num_RotY.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.num_RotY.Maximum = new decimal(new int[] {
-            999,
-            0,
-            0,
-            0});
-            this.num_RotY.Minimum = new decimal(new int[] {
-            999,
-            0,
-            0,
-            -2147483648});
-            this.num_RotY.Name = "num_RotY";
-            this.num_RotY.Size = new System.Drawing.Size(90, 27);
-            this.num_RotY.TabIndex = 7;
+            num_RotY.Anchor =   System.Windows.Forms.AnchorStyles.Left  |  System.Windows.Forms.AnchorStyles.Right  ;
+            num_RotY.BackColor = System.Drawing.Color.Transparent;
+            num_RotY.BackgroundColor = System.Drawing.Color.Empty;
+            num_RotY.BorderColor = System.Drawing.Color.FromArgb(   110  ,   110  ,   110   );
+            num_RotY.DisabledBackColor = System.Drawing.Color.FromArgb(   80  ,   80  ,   80   );
+            num_RotY.DisabledBorderColor = System.Drawing.Color.FromArgb(   109  ,   109  ,   109   );
+            num_RotY.DisabledForeColor = System.Drawing.Color.FromArgb(   109  ,   109  ,   109   );
+            num_RotY.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            num_RotY.IsDerivedStyle = true;
+            num_RotY.Location = new System.Drawing.Point( 61, 134 );
+            num_RotY.Margin = new System.Windows.Forms.Padding( 4, 5, 4, 5 );
+            num_RotY.Maximum = 999;
+            num_RotY.Minimum = -999;
+            num_RotY.Name = "num_RotY";
+            num_RotY.Size = new System.Drawing.Size( 159, 26 );
+            num_RotY.Style = MetroSet_UI.Enums.Style.Dark;
+            num_RotY.StyleManager = null;
+            num_RotY.SymbolsColor = System.Drawing.Color.FromArgb(   110  ,   110  ,   110   );
+            num_RotY.TabIndex = 7;
+            num_RotY.ThemeAuthor = "Narwin";
+            num_RotY.ThemeName = "MetroDark";
+            num_RotY.Value = 0;
             // 
             // num_RotZ
             // 
-            this.num_RotZ.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.num_RotZ.DecimalPlaces = 7;
-            this.num_RotZ.Location = new System.Drawing.Point(37, 117);
-            this.num_RotZ.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.num_RotZ.Maximum = new decimal(new int[] {
-            999,
-            0,
-            0,
-            0});
-            this.num_RotZ.Minimum = new decimal(new int[] {
-            999,
-            0,
-            0,
-            -2147483648});
-            this.num_RotZ.Name = "num_RotZ";
-            this.num_RotZ.Size = new System.Drawing.Size(90, 27);
-            this.num_RotZ.TabIndex = 9;
+            num_RotZ.Anchor =   System.Windows.Forms.AnchorStyles.Left  |  System.Windows.Forms.AnchorStyles.Right  ;
+            num_RotZ.BackColor = System.Drawing.Color.Transparent;
+            num_RotZ.BackgroundColor = System.Drawing.Color.Empty;
+            num_RotZ.BorderColor = System.Drawing.Color.FromArgb(   110  ,   110  ,   110   );
+            num_RotZ.DisabledBackColor = System.Drawing.Color.FromArgb(   80  ,   80  ,   80   );
+            num_RotZ.DisabledBorderColor = System.Drawing.Color.FromArgb(   109  ,   109  ,   109   );
+            num_RotZ.DisabledForeColor = System.Drawing.Color.FromArgb(   109  ,   109  ,   109   );
+            num_RotZ.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            num_RotZ.IsDerivedStyle = true;
+            num_RotZ.Location = new System.Drawing.Point( 61, 193 );
+            num_RotZ.Margin = new System.Windows.Forms.Padding( 4, 5, 4, 5 );
+            num_RotZ.Maximum = 999;
+            num_RotZ.Minimum = -999;
+            num_RotZ.Name = "num_RotZ";
+            num_RotZ.Size = new System.Drawing.Size( 159, 26 );
+            num_RotZ.Style = MetroSet_UI.Enums.Style.Dark;
+            num_RotZ.StyleManager = null;
+            num_RotZ.SymbolsColor = System.Drawing.Color.FromArgb(   110  ,   110  ,   110   );
+            num_RotZ.TabIndex = 9;
+            num_RotZ.ThemeAuthor = "Narwin";
+            num_RotZ.ThemeName = "MetroDark";
+            num_RotZ.Value = 0;
             // 
             // lbl_Rotation
             // 
-            this.lbl_Rotation.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.lbl_Rotation.AutoSize = true;
-            this.lbl_Rotation.Location = new System.Drawing.Point(61, 5);
-            this.lbl_Rotation.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lbl_Rotation.Name = "lbl_Rotation";
-            this.lbl_Rotation.Size = new System.Drawing.Size(66, 20);
-            this.lbl_Rotation.TabIndex = 5;
-            this.lbl_Rotation.Text = "Rotation";
+            lbl_Rotation.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            lbl_Rotation.AutoSize = true;
+            lbl_Rotation.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            lbl_Rotation.IsDerivedStyle = true;
+            lbl_Rotation.Location = new System.Drawing.Point( 149, 19 );
+            lbl_Rotation.Margin = new System.Windows.Forms.Padding( 4, 0, 4, 0 );
+            lbl_Rotation.Name = "lbl_Rotation";
+            lbl_Rotation.Size = new System.Drawing.Size( 71, 20 );
+            lbl_Rotation.Style = MetroSet_UI.Enums.Style.Dark;
+            lbl_Rotation.StyleManager = null;
+            lbl_Rotation.TabIndex = 5;
+            lbl_Rotation.Text = "Rotation";
+            lbl_Rotation.ThemeAuthor = "Narwin";
+            lbl_Rotation.ThemeName = "MetroDark";
             // 
             // num_RotW
             // 
-            this.num_RotW.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.num_RotW.DecimalPlaces = 7;
-            this.num_RotW.Location = new System.Drawing.Point(37, 153);
-            this.num_RotW.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.num_RotW.Maximum = new decimal(new int[] {
-            999,
-            0,
-            0,
-            0});
-            this.num_RotW.Minimum = new decimal(new int[] {
-            999,
-            0,
-            0,
-            -2147483648});
-            this.num_RotW.Name = "num_RotW";
-            this.num_RotW.Size = new System.Drawing.Size(90, 27);
-            this.num_RotW.TabIndex = 11;
-            this.num_RotW.Value = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
+            num_RotW.Anchor =   System.Windows.Forms.AnchorStyles.Left  |  System.Windows.Forms.AnchorStyles.Right  ;
+            num_RotW.BackColor = System.Drawing.Color.Transparent;
+            num_RotW.BackgroundColor = System.Drawing.Color.Empty;
+            num_RotW.BorderColor = System.Drawing.Color.FromArgb(   110  ,   110  ,   110   );
+            num_RotW.DisabledBackColor = System.Drawing.Color.FromArgb(   80  ,   80  ,   80   );
+            num_RotW.DisabledBorderColor = System.Drawing.Color.FromArgb(   109  ,   109  ,   109   );
+            num_RotW.DisabledForeColor = System.Drawing.Color.FromArgb(   109  ,   109  ,   109   );
+            num_RotW.Font = new System.Drawing.Font( "Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point );
+            num_RotW.IsDerivedStyle = true;
+            num_RotW.Location = new System.Drawing.Point( 61, 254 );
+            num_RotW.Margin = new System.Windows.Forms.Padding( 4, 5, 4, 5 );
+            num_RotW.Maximum = 999;
+            num_RotW.Minimum = 0;
+            num_RotW.Name = "num_RotW";
+            num_RotW.Size = new System.Drawing.Size( 159, 26 );
+            num_RotW.Style = MetroSet_UI.Enums.Style.Dark;
+            num_RotW.StyleManager = null;
+            num_RotW.SymbolsColor = System.Drawing.Color.FromArgb(   110  ,   110  ,   110   );
+            num_RotW.TabIndex = 11;
+            num_RotW.ThemeAuthor = "Narwin";
+            num_RotW.ThemeName = "MetroDark";
+            num_RotW.Value = 1;
+            // 
+            // tableLayoutPanel1
+            // 
+            tableLayoutPanel1.ColumnCount = 3;
+            tableLayoutPanel1.ColumnStyles.Add( new System.Windows.Forms.ColumnStyle( System.Windows.Forms.SizeType.Percent, 33.3333321F ) );
+            tableLayoutPanel1.ColumnStyles.Add( new System.Windows.Forms.ColumnStyle( System.Windows.Forms.SizeType.Percent, 33.3333321F ) );
+            tableLayoutPanel1.ColumnStyles.Add( new System.Windows.Forms.ColumnStyle( System.Windows.Forms.SizeType.Percent, 33.3333321F ) );
+            tableLayoutPanel1.Controls.Add( OKButton, 2, 1 );
+            tableLayoutPanel1.Controls.Add( tableLayoutPanel_Pos, 2, 0 );
+            tableLayoutPanel1.Controls.Add( tableLayoutPanel_Rot, 1, 0 );
+            tableLayoutPanel1.Controls.Add( tableLayoutPanel_Scale, 0, 0 );
+            tableLayoutPanel1.Controls.Add( CancelButton, 1, 1 );
+            tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            tableLayoutPanel1.Location = new System.Drawing.Point( 2, 0 );
+            tableLayoutPanel1.Name = "tableLayoutPanel1";
+            tableLayoutPanel1.RowCount = 2;
+            tableLayoutPanel1.RowStyles.Add( new System.Windows.Forms.RowStyle( System.Windows.Forms.SizeType.Percent, 80F ) );
+            tableLayoutPanel1.RowStyles.Add( new System.Windows.Forms.RowStyle( System.Windows.Forms.SizeType.Percent, 20F ) );
+            tableLayoutPanel1.Size = new System.Drawing.Size( 696, 385 );
+            tableLayoutPanel1.TabIndex = 11;
             // 
             // SetScaleValueDialog
             // 
-            this.AcceptButton = this.OKButton;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(398, 242);
-            this.Controls.Add(this.tableLayoutPanel_Rot);
-            this.Controls.Add(this.tableLayoutPanel_Pos);
-            this.Controls.Add(this.OKButton);
-            this.Controls.Add(this.CancelButton);
-            this.Controls.Add(this.tableLayoutPanel_Scale);
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.MaximizeBox = false;
-            this.Name = "SetScaleValueDialog";
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "Scale/Reposition";
-            this.tableLayoutPanel_Scale.ResumeLayout(false);
-            this.tableLayoutPanel_Scale.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.num_ScaleX)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.num_ScaleY)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.num_ScaleZ)).EndInit();
-            this.tableLayoutPanel_Pos.ResumeLayout(false);
-            this.tableLayoutPanel_Pos.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.num_PosX)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.num_PosY)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.num_PosZ)).EndInit();
-            this.tableLayoutPanel_Rot.ResumeLayout(false);
-            this.tableLayoutPanel_Rot.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.num_RotX)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.num_RotY)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.num_RotZ)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.num_RotW)).EndInit();
-            this.ResumeLayout(false);
-
+            AcceptButton = OKButton;
+            AutoScaleDimensions = new System.Drawing.SizeF( 120F, 120F );
+            
+            BackColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            BackgroundColor = System.Drawing.Color.FromArgb(   30  ,   30  ,   30   );
+            ClientSize = new System.Drawing.Size( 700, 387 );
+            Controls.Add( tableLayoutPanel1 );
+            DropShadowEffect = false;
+            FormBorderStyle = System.Windows.Forms.FormBorderStyle.Sizable;
+            HeaderHeight = -40;
+            Icon = (System.Drawing.Icon) resources.GetObject( "$this.Icon" ) ;
+            Margin = new System.Windows.Forms.Padding( 4, 5, 4, 5 );
+            Name = "SetScaleValueDialog";
+            Opacity = 0.99D;
+            Padding = new System.Windows.Forms.Padding( 2, 0, 2, 2 );
+            ShowHeader = true;
+            ShowLeftRect = false;
+            SizeGripStyle = System.Windows.Forms.SizeGripStyle.Show;
+            StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            Style = MetroSet_UI.Enums.Style.Dark;
+            Text = "Scale/Reposition";
+            ThemeName = "MetroDark";
+            tableLayoutPanel_Scale.ResumeLayout( false );
+            tableLayoutPanel_Scale.PerformLayout();
+            tableLayoutPanel_Pos.ResumeLayout( false );
+            tableLayoutPanel_Pos.PerformLayout();
+            tableLayoutPanel_Rot.ResumeLayout( false );
+            tableLayoutPanel_Rot.PerformLayout();
+            tableLayoutPanel1.ResumeLayout( false );
+            ResumeLayout( false );
         }
 
         #endregion
@@ -568,30 +701,31 @@
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel_Scale;
         private new System.Windows.Forms.Button CancelButton;
         private System.Windows.Forms.Button OKButton;
-        private System.Windows.Forms.Label lbl_scaleX;
-        private System.Windows.Forms.NumericUpDown num_ScaleX;
-        private System.Windows.Forms.Label lbl_ScaleZ;
-        private System.Windows.Forms.Label lbl_Scale;
-        private System.Windows.Forms.Label lbl_ScaleY;
-        private System.Windows.Forms.NumericUpDown num_ScaleY;
-        private System.Windows.Forms.NumericUpDown num_ScaleZ;
+        private MetroSetLabel lbl_scaleX;
+        private MetroSetNumeric num_ScaleX;
+        private MetroSetLabel lbl_ScaleZ;
+        private MetroSetLabel lbl_Scale;
+        private MetroSetLabel lbl_ScaleY;
+        private MetroSetNumeric num_ScaleY;
+        private MetroSetNumeric num_ScaleZ;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel_Pos;
-        private System.Windows.Forms.Label lbl_PosZ;
-        private System.Windows.Forms.Label lbl_PosX;
-        private System.Windows.Forms.NumericUpDown num_PosX;
-        private System.Windows.Forms.Label lbl_Position;
-        private System.Windows.Forms.Label lbl_PosY;
-        private System.Windows.Forms.NumericUpDown num_PosY;
-        private System.Windows.Forms.NumericUpDown num_PosZ;
+        private MetroSetLabel lbl_PosZ;
+        private MetroSetLabel lbl_PosX;
+        private MetroSetNumeric num_PosX;
+        private MetroSetLabel lbl_Position;
+        private MetroSetLabel lbl_PosY;
+        private MetroSetNumeric num_PosY;
+        private MetroSetNumeric num_PosZ;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel_Rot;
-        private System.Windows.Forms.Label lbl_RotW;
-        private System.Windows.Forms.Label lbl_RotZ;
-        private System.Windows.Forms.Label lbl_RotX;
-        private System.Windows.Forms.NumericUpDown num_RotX;
-        private System.Windows.Forms.Label lbl_RotY;
-        private System.Windows.Forms.NumericUpDown num_RotY;
-        private System.Windows.Forms.NumericUpDown num_RotZ;
-        private System.Windows.Forms.Label lbl_Rotation;
-        private System.Windows.Forms.NumericUpDown num_RotW;
+        private MetroSetLabel lbl_RotW;
+        private MetroSetLabel lbl_RotZ;
+        private MetroSetLabel lbl_RotX;
+        private MetroSetNumeric num_RotX;
+        private MetroSetLabel lbl_RotY;
+        private MetroSetNumeric num_RotY;
+        private MetroSetNumeric num_RotZ;
+        private MetroSetLabel lbl_Rotation;
+        private MetroSetNumeric num_RotW;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
     }
 }

--- a/GFDStudio/GUI/Forms/SetScaleValueDialog.cs
+++ b/GFDStudio/GUI/Forms/SetScaleValueDialog.cs
@@ -1,10 +1,11 @@
-﻿using System;
+﻿using MetroSet_UI.Forms;
+using System;
 using System.Numerics;
 using System.Windows.Forms;
 
 namespace GFDStudio.GUI.Forms
 {
-    public partial class SetScaleValueDialog : Form
+    public partial class SetScaleValueDialog : MetroSetForm
     {
         public ResultValue Result { get; private set; }
 
@@ -22,14 +23,14 @@ namespace GFDStudio.GUI.Forms
         {
             private readonly SetScaleValueDialog mParent;
 
-            internal ResultValue(SetScaleValueDialog parent )
+            internal ResultValue( SetScaleValueDialog parent )
             {
                 mParent = parent;
             }
 
-            public Vector3 Scale => new Vector3 { X = Convert.ToSingle(mParent.num_ScaleX.Value), Y = Convert.ToSingle(mParent.num_ScaleY.Value), Z = Convert.ToSingle(mParent.num_ScaleZ.Value) };
-            public Vector3 Position => new Vector3 { X = Convert.ToSingle(mParent.num_PosX.Value), Y = Convert.ToSingle(mParent.num_PosY.Value), Z = Convert.ToSingle(mParent.num_PosZ.Value) };
-            public Quaternion Rotation => new Quaternion { X = Convert.ToSingle(mParent.num_RotX.Value), Y = Convert.ToSingle(mParent.num_RotY.Value), Z = Convert.ToSingle(mParent.num_RotZ.Value), W = Convert.ToSingle(mParent.num_RotW.Value) };
+            public Vector3 Scale => new Vector3 { X = Convert.ToSingle( mParent.num_ScaleX.Value ), Y = Convert.ToSingle( mParent.num_ScaleY.Value ), Z = Convert.ToSingle( mParent.num_ScaleZ.Value ) };
+            public Vector3 Position => new Vector3 { X = Convert.ToSingle( mParent.num_PosX.Value ), Y = Convert.ToSingle( mParent.num_PosY.Value ), Z = Convert.ToSingle( mParent.num_PosZ.Value ) };
+            public Quaternion Rotation => new Quaternion { X = Convert.ToSingle( mParent.num_RotX.Value ), Y = Convert.ToSingle( mParent.num_RotY.Value ), Z = Convert.ToSingle( mParent.num_RotZ.Value ), W = Convert.ToSingle( mParent.num_RotW.Value ) };
 
         }
     }

--- a/GFDStudio/GUI/Forms/SetScaleValueDialog.resx
+++ b/GFDStudio/GUI/Forms/SetScaleValueDialog.resx
@@ -1,4 +1,64 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema 
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing"">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">

--- a/GFDStudio/Program.cs
+++ b/GFDStudio/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Drawing;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -51,5 +52,66 @@ namespace GFDStudio
         [return: MarshalAs( UnmanagedType.Bool )]
         static extern bool AllocConsole();
 #endif
+    }
+
+    public class CustomMenuRenderer : ToolStripProfessionalRenderer
+    {
+        public CustomMenuRenderer() : base( new CustomColors() ) { }
+    }
+    public class CustomColors : ProfessionalColorTable
+    {
+        public override Color MenuItemSelected
+        {
+            get { return Color.FromArgb( 20, 20, 20 ); }
+        }
+        public override Color MenuItemBorder
+        {
+            get { return Color.FromArgb( 20, 20, 20 ); }
+        }
+        public override Color MenuBorder
+        {
+            get { return Color.FromArgb( 20, 20, 20 ); }
+        }
+        public override Color MenuItemSelectedGradientBegin
+        {
+            get { return Color.FromArgb( 20, 20, 20 ); }
+        }
+        public override Color MenuItemSelectedGradientEnd
+        {
+            get { return Color.FromArgb( 20, 20, 20 ); }
+        }
+
+        public override Color ToolStripDropDownBackground
+        {
+            get { return Color.FromArgb( 20, 20, 20 ); }
+        }
+        public override Color SeparatorDark
+        {
+            get { return Color.FromArgb( 20, 20, 20 ); }
+        }
+        public override Color SeparatorLight
+        {
+            get { return Color.FromArgb( 20, 20, 20 ); }
+        }
+        public override Color MenuItemPressedGradientBegin
+        {
+            get { return Color.FromArgb( 20, 20, 20 ); }
+        }
+        public override Color MenuItemPressedGradientEnd
+        {
+            get { return Color.FromArgb( 20, 20, 20 ); }
+        }
+        public override Color MenuStripGradientBegin
+        {
+            get { return Color.FromArgb( 20, 20, 20 ); }
+        }
+        public override Color MenuStripGradientEnd
+        {
+            get { return Color.FromArgb( 20, 20, 20 ); }
+        }
+        public override Color ToolStripBorder
+        {
+            get { return Color.FromArgb( 20, 20, 20 ); }
+        }
     }
 }

--- a/GFDStudio/app_data/shaders/default.glsl.fs
+++ b/GFDStudio/app_data/shaders/default.glsl.fs
@@ -1,9 +1,11 @@
-﻿
-#version 330 core
+﻿ #version 330 core
+
+// thanks dniwetamp
 
 // in
 in vec3 fPosition;
 in vec3 fNormal;
+in vec3 fFacingNormal;
 in vec2 fTex0;
 in vec4 fColor0;
 
@@ -12,74 +14,227 @@ out vec4 oColor;
 
 // samplers
 uniform sampler2D uDiffuse;
+uniform sampler2D uSpecular;
+uniform sampler2D uShadow;
 
 // material properties
 uniform bool uMatHasDiffuse;
+uniform bool uMatHasSpecular;
+uniform bool uMatHasShadow;
 uniform vec4 uMatAmbient;
 uniform vec4 uMatDiffuse;
-uniform vec4 uMatSpecular;
 uniform vec4 uMatEmissive;
-uniform bool uMatHasAlphaTransparency;
+uniform int DrawMethod;
+uniform bool uMatHasType0;
+uniform bool uMatHasType1;
+uniform bool uMatHasType4;
+uniform int uMatType0Flags;
 
-float luma(vec3 color) {
-  return dot(color, vec3(0.299, 0.587, 0.114));
+uniform vec4 uMatToonLightColor;
+uniform float uMatToonLightThreshold;
+uniform float uMatToonLightFactor;
+uniform float uMatToonShadowBrightness;
+uniform float uMatToonShadowThreshold;
+uniform float uMatToonShadowFactor;
+
+float mapRange(float value, float min1, float max1, float min2, float max2) {
+  return min2 + (value - min1) * (max2 - min2) / (max1 - min1);
 }
 
-float luma(vec4 color) {
-  return dot(color.rgb, vec3(0.299, 0.587, 0.114));
+float RGBAtoGray(vec4 RGBA) {
+    return (RGBA.r+RGBA.g+RGBA.b)/3.0;
+}
+
+void DefaultShader()
+{
+    vec4 diffuseColor;
+    vec4 specularColor = vec4(0.0);
+    vec4 shadowColor = vec4(1.0);
+    vec3 lightDirection = vec3( 10.0, 45, 10.0 );
+
+    if ( uMatHasDiffuse )
+    {
+        diffuseColor = texture( uDiffuse, fTex0 );
+        diffuseColor.a *= uMatDiffuse.a;
+        if (DrawMethod == 2) // Black as Alpha
+        {
+            diffuseColor.a *= RGBAtoGray(diffuseColor);
+        }
+        if ( diffuseColor.a < 0.2 ) //alpha clip
+            discard;
+    }
+    else
+    {
+        diffuseColor = uMatDiffuse;
+        if (DrawMethod == 2) // Black as Alpha
+        {
+            diffuseColor.a *= RGBAtoGray(diffuseColor);
+        }
+        if ( diffuseColor.a < 0.2 ) //alpha clip
+            discard;
+    }
+    if ( uMatHasSpecular )
+    {
+        specularColor = texture( uSpecular, fTex0 );
+    }
+    if (uMatHasShadow)
+    {
+        shadowColor = texture( uShadow, fTex0 );
+        shadowColor.rgb = vec3(1.0 - shadowColor.r, 1.0 - shadowColor.g, 1.0 - shadowColor.b);
+    }
+
+
+    //  basic shadow using normals
+    float phongShadow = dot(normalize(lightDirection),normalize(fFacingNormal));
+    float clampedPhongShadow = clamp(phongShadow, 0.0, 1.0);
+    vec4 shadow = clamp((vec4(clampedPhongShadow) * vec4(shadowColor.rgb, 1.0) + uMatAmbient), 0, 1);
+    // Phong specular
+    vec3 ref = reflect(-normalize(lightDirection), normalize(fFacingNormal));
+    float specAngle = max(dot(ref, normalize(-fPosition)), 0.0);
+    vec4 specular = vec4(0.0);
+    if ( uMatEmissive.a > 0.0 )
+        specular = vec4(pow(specAngle, uMatEmissive.a));
+
+    vec4 accumulatedColor = diffuseColor + vec4(uMatEmissive.rgb, 1.0) * specular * specularColor;
+    accumulatedColor *= shadow;
+    oColor = accumulatedColor;
+}
+
+void CharacterShader()
+{
+    vec4 diffuseColor;
+    vec4 specularColor = vec4(0.0);
+    vec4 shadowColor = vec4(1.0);
+    vec4 toonShadow = vec4(1.0);
+    vec3 lightDirection = vec3( 90.0, 45.0, 90.0 );
+    vec3 eyePos = normalize( -fPosition );
+
+    if ( uMatHasDiffuse )
+    {
+        diffuseColor = texture( uDiffuse, fTex0 );
+        diffuseColor.a *= uMatDiffuse.a;
+        if (DrawMethod == 2) // Black as Alpha
+        {
+            diffuseColor.a *= RGBAtoGray(diffuseColor);
+        }
+        if ( diffuseColor.a < 0.2 ) //alpha clip
+            discard;
+    }
+    else
+    {
+        diffuseColor = uMatDiffuse;
+        if (DrawMethod == 2) // Black as Alpha
+        {
+            diffuseColor.a *= RGBAtoGray(diffuseColor);
+        }
+        if ( diffuseColor.a < 0.2 ) //alpha clip
+            discard;
+    }
+    if ( uMatHasSpecular )
+    {
+        specularColor = texture( uSpecular, fTex0 );
+    }
+    if (uMatHasShadow)
+    {
+        shadowColor = texture( uShadow, fTex0 );
+        shadowColor.rgb = vec3(1.0 - shadowColor.r, 1.0 - shadowColor.g, 1.0 - shadowColor.b);
+    }
+
+    //  basic shadow using normals
+    float phongShadow = dot(normalize(lightDirection),normalize(fFacingNormal));
+    float clampedPhongShadow = clamp(phongShadow, 0.0, 1.0);
+    // Ramp the shadow, copypasted from p5r shader
+    float D = clamp((max(clampedPhongShadow - pow(uMatToonShadowThreshold, 1.8), 0.0) * uMatToonShadowFactor), 0, 1);
+    if (uMatType0Flags != 77)
+        toonShadow = vec4(D);
+    toonShadow.rgb *= shadowColor.rgb;
+    // Calculate rim light, copypasted from p5r shader
+    float NVW = clamp(( dot( fFacingNormal, mix( eyePos, fFacingNormal, -min( phongShadow, 0.0) ) )), 0.0, 1.0);
+    float E = pow(( min( 1.0 - NVW, uMatToonLightThreshold) / uMatToonLightThreshold), uMatToonLightFactor);
+
+    // Phong Specular
+    vec3 ref = reflect(-normalize(lightDirection), normalize(fFacingNormal));
+    float specAngle = max(dot(ref, normalize(-fPosition)), 0.0);
+    vec4 specular = vec4(0.0);
+    if ( uMatEmissive.a > 0.0 )
+        specular = vec4(pow(specAngle, uMatEmissive.a));
+    //colorize toon shadow, using ambient color values
+    toonShadow.xyz = clamp((toonShadow.xyz + uMatAmbient.xyz), 0, 1);
+    //Calculate accumated color so far
+    vec4 accumulatedColor = diffuseColor + vec4(uMatEmissive.rgb, 1.0) * specular * specularColor;
+    accumulatedColor = mix(accumulatedColor, uMatToonLightColor, E * uMatToonLightColor.a * shadowColor.a );
+    vec4 addedShadow = accumulatedColor * toonShadow;
+    accumulatedColor = mix(accumulatedColor, addedShadow, 1.0 - uMatToonShadowBrightness);
+
+    oColor = accumulatedColor;
+}
+
+void PersonaShader()
+{
+    vec4 diffuseColor;
+    vec4 specularColor = vec4(0.0);
+    vec4 shadowColor = vec4(1.0);
+    vec4 toonShadow = vec4(1.0);
+    vec3 lightDirection = vec3( 90.0, 45.0, 90.0 );
+    vec3 eyePos = normalize( -fPosition );
+
+    if ( uMatHasDiffuse )
+    {
+        diffuseColor = texture( uDiffuse, fTex0 );
+            diffuseColor.a *= uMatDiffuse.a;
+        if (DrawMethod == 2) // Black as Alpha
+        {
+            diffuseColor.a *= RGBAtoGray(diffuseColor);
+        }
+        if ( diffuseColor.a < 0.2 && DrawMethod == 1) //alpha clip
+            discard;
+    }
+    else
+    {
+        diffuseColor = uMatDiffuse;
+        if (DrawMethod == 2) // Black as Alpha
+        {
+            diffuseColor.a *= RGBAtoGray(diffuseColor);
+        }
+        if ( diffuseColor.a < 0.2 ) //alpha clip
+            discard;
+    }
+    if ( uMatHasSpecular )
+    {
+        specularColor = texture( uSpecular, fTex0 );
+    }
+    if (uMatHasShadow)
+    {
+        shadowColor = texture( uShadow, fTex0 );
+        shadowColor.rgb = vec3(1.0 - shadowColor.r, 1.0 - shadowColor.g, 1.0 - shadowColor.b);
+    }
+
+    float phongShadow = dot(normalize(lightDirection),normalize(fFacingNormal));
+    // Calculate rim light, copypasted from p5r shader
+    float NVW = clamp(( dot( fFacingNormal, mix( eyePos, fFacingNormal, -min( phongShadow, 0.0) ) )), 0.0, 1.0);
+    float E = pow(( min( 1.0 - NVW, uMatToonLightThreshold) / uMatToonLightThreshold), uMatToonLightFactor);
+    // Phong Specular
+    vec3 ref = reflect(-normalize(lightDirection), normalize(fFacingNormal));
+    float specAngle = max(dot(ref, normalize(-fPosition)), 0.0);
+    vec4 specular = vec4(0.0);
+    if ( uMatEmissive.a > 0.0 )
+        specular = vec4(pow(specAngle, uMatEmissive.a));
+    //colorize toon shadow, using ambient color values
+    toonShadow.xyz = clamp((toonShadow.xyz + uMatAmbient.xyz), 0, 1);
+    //Calculate accumated color so far
+    vec4 accumulatedColor = diffuseColor + vec4(uMatEmissive.rgb, 1.0) * specular * specularColor;
+    //accumulatedColor *= vec4(phongShadow);
+    accumulatedColor = mix(accumulatedColor, uMatToonLightColor, E * uMatToonLightColor.a * diffuseColor.a );
+
+    oColor = accumulatedColor;
 }
 
 void main()
 {
-	vec4 diffuseColor;
-	
-	if ( uMatHasDiffuse )
-	{
-		diffuseColor = texture( uDiffuse, fTex0 );
-		if ( uMatHasAlphaTransparency && diffuseColor.a < 0.1 )
-			discard;
-	}
-	else
-	{
-		diffuseColor = uMatDiffuse;
-	}
-
-	vec3 lightDirection = vec3( 0.0, 0.0, -1.0 );
-	vec3 eyePos = normalize( -fPosition );
-	vec3 reflection = normalize( -reflect( lightDirection, fNormal ) );
-
-	// Calculate ambient
-	vec4 ambient = clamp( uMatAmbient, 0.0f, 0.025f );
-
-	// Calculate diffuse
-	vec4 diffuse = uMatDiffuse * max( dot( fNormal, lightDirection), 0.0 );
-
-	// Calculate specular
-	//vec4 specular = uMatSpecular * pow( max( dot( reflection, eyePos ), 0.0 ), 0.3 * 0.25 );
-
-	// Calculate accumated color so far
-	vec4 accumulatedColor = diffuseColor + ambient + diffuse; // + specular;
-
-	if ( uMatHasDiffuse )
-	{
-		// Calculate rim light
-		float rimWidth = 0.65;
-		float rimPower = 0.9;	
-		float rimIntensity = rimWidth - max( dot( eyePos, fNormal ), 0.0 );
-		rimIntensity = max( 0.0, rimIntensity * rimPower ); // ignore rim light if negative
-		
-		/*
-		float brightness = clamp( luma( accumulatedColor ), 0.0, 1.0 );
-		rimIntensity = rimIntensity / ( ( brightness / 0.5 ) * 2.0 ); 
-		*/
-
-		vec4 rimColor = vec4( rimIntensity * uMatAmbient.xyz, 1.0 );
-
-		// Calculate final fment color
-		oColor = accumulatedColor + rimColor;
-	}
-	else
-	{
-		oColor = accumulatedColor;
-	}
+    if (uMatHasType0)
+        CharacterShader();
+    else if (uMatHasType1 || uMatHasType4)
+        PersonaShader();
+    else
+        DefaultShader();
 }

--- a/GFDStudio/app_data/shaders/default.glsl.vs
+++ b/GFDStudio/app_data/shaders/default.glsl.vs
@@ -11,6 +11,7 @@ layout( location = 4 ) in uvec4 vBoneIndices;
 // out
 out vec3 fPosition;
 out vec3 fNormal;
+out vec3 fFacingNormal;
 out vec2 fTex0;
 out vec4 fColor0;
 
@@ -21,10 +22,11 @@ uniform mat4 uProjection;
 
 void main()
 {
-	mat4 uModelView = uView * uModel;
-	fPosition = ( uModelView * vec4( vPosition, 1.0 ) ).xyz;
-	fNormal = ( uModelView * vec4( vNormal, 0.0 ) ).xyz;
-	fTex0 = vTex0;
-	fColor0 = vec4( 1.0, 1.0, 1.0, 1.0 );
-	gl_Position = uProjection * uModelView * vec4( vPosition, 1.0 );
+    mat4 uModelView = uView * uModel;
+    fPosition = ( uModelView * vec4( vPosition, 1.0 ) ).xyz;
+    fNormal = vNormal.xyz;
+    fFacingNormal = ( uModelView * vec4( vNormal, 0.0 ) ).xyz;
+    fTex0 = vTex0;
+    fColor0 = vec4( 1.0, 1.0, 1.0, 1.0 );
+    gl_Position = uProjection * uModelView * vec4( vPosition, 1.0 );
 }


### PR DESCRIPTION
- Merge (and update) improved shader from Dniwe's fork
- Add dark mode to form using MetroSetUI
- Use custom toolstrip renderer
- Fix DPI awareness
- Shrink 3d grid dimensions
- Allow resizing form elements using SplitContainers
- disable Convert All Mats To Preset (since it's broken)