### PR TITLE
Add animation export and fix model import regression

### DIFF
--- a/GFDLibrary.Conversion.AssimpNet/AssimpNetModelConverter.cs
+++ b/GFDLibrary.Conversion.AssimpNet/AssimpNetModelConverter.cs
@@ -481,14 +481,34 @@ namespace GFDLibrary.Conversion.AssimpNet
                 var nodeInfo = nodeLookup[AssimpConverterCommon.UnescapeName( aiNode.Name )];
                 Node targetNode = nodeInfo.Node;
                 var sourceToTargetModelMatrix = Matrix4x4.Identity;
-                if ( nodeInfo.IsMeshAttachment && nodeInfo.Node.Parent?.Name == "RootNode")
+                if ( nodeInfo.IsMeshAttachment )
                 {
-                    var originalParentNodeName = nodeInfo.Node.Name[..nodeInfo.Node.Name.IndexOf( ModelConversionHelpers.MeshAttachmentNameSuffix )];
-                    if ( nodeLookup.TryGetValue( originalParentNodeName, out var originalParentNodeInfo ) )
+                    if ( nodeInfo.Node.Parent?.Name == "RootNode" )
                     {
-                        targetNode = originalParentNodeInfo.Node;
-                        // Need to transform the vertices from the local space of the original node to the local space of the new node
-                        sourceToTargetModelMatrix = targetNode.WorldTransform.Inverted() * nodeInfo.Node.WorldTransform;
+                        // New convention (FBX SDK exporter): <originalParent>_gfdMesh_<N> parented under RootNode.
+                        // Look up the original parent by stripping the suffix.
+                        var suffixIndex = nodeInfo.Node.Name.IndexOf( ModelConversionHelpers.MeshAttachmentNameSuffix );
+                        if ( suffixIndex >= 0 )
+                        {
+                            var originalParentNodeName = nodeInfo.Node.Name[..suffixIndex];
+                            if ( nodeLookup.TryGetValue( originalParentNodeName, out var originalParentNodeInfo ) )
+                            {
+                                targetNode = originalParentNodeInfo.Node;
+                                // Need to transform the vertices from the local space of the original node to the local space of the new node
+                                sourceToTargetModelMatrix = targetNode.WorldTransform.Inverted() * nodeInfo.Node.WorldTransform;
+                            }
+                            else if ( nodeInfo.Node.Parent != null )
+                            {
+                                Logger.Info( $"Mesh attachment '{nodeInfo.Node.Name}' references unknown parent '{originalParentNodeName}'; attaching to its current parent instead." );
+                                targetNode = nodeInfo.Node.Parent;
+                            }
+                        }
+                    }
+                    else if ( nodeInfo.Node.Parent != null )
+                    {
+                        // Legacy convention (GMD Maxscript): <bone>_Mesh<N> parented under the bone itself.
+                        // IsLegacyMeshAttachmentNode guarantees identity local transform, so no vertex transform is needed.
+                        targetNode = nodeInfo.Node.Parent;
                     }
                 }
 

--- a/GFDLibrary.Conversion.FbxSdk/FbxSdkAnimationExporter.cpp
+++ b/GFDLibrary.Conversion.FbxSdk/FbxSdkAnimationExporter.cpp
@@ -1,0 +1,304 @@
+#include "pch.h"
+
+#include "FbxSdkAnimationExporter.h"
+#include "Utf8String.h"
+
+/*
+	FBX ANIMATION EXPORTER NOTES:
+	- Exports a skeleton-only FBX (FbxNode tree with FbxSkeleton::eLimbNode attributes)
+	- Only TargetKind.Node controllers are converted
+*/
+
+using namespace System;
+using namespace System::Collections::Generic;
+using namespace System::Diagnostics;
+using namespace System::Numerics;
+
+namespace GFDLibrary::Conversion::FbxSdk
+{
+	using namespace Models;
+	using namespace Animations;
+
+	static FbxDouble3 ConvertToFbxDouble3(Vector3 value)
+	{
+		return FbxDouble3(value.X, value.Y, value.Z);
+	}
+
+	static FbxQuaternion ConvertToFbxQuaternion(Quaternion value)
+	{
+		return FbxQuaternion(value.X, value.Y, value.Z, value.W);
+	}
+
+	FbxSdkAnimationExporter::FbxSdkAnimationExporter()
+	{
+		mFbxManager = FbxManager::Create();
+		if (!mFbxManager)
+			throw gcnew FbxSdkAnimationExporterException("Failed to create FBX Manager");
+
+		mNameToFbxNodeLookup = gcnew Dictionary<String^, IntPtr>();
+	}
+
+	FbxSdkAnimationExporter::~FbxSdkAnimationExporter()
+	{
+		mFbxManager->Destroy();
+	}
+
+	void FbxSdkAnimationExporter::Reset()
+	{
+		mNameToFbxNodeLookup->Clear();
+	}
+
+	void FbxSdkAnimationExporter::BuildSkeletonRecursive(FbxNode* fbxParentNode, Node^ node)
+	{
+		auto fbxNode = FbxNode::Create(mFbxScene, Utf8String(node->Name).ToCStr());
+
+		// Local transform from GFD node
+		FbxAMatrix m;
+		m.SetQ(ConvertToFbxQuaternion(node->Rotation));
+		fbxNode->LclRotation.Set(m.GetR());
+		fbxNode->LclScaling.Set(ConvertToFbxDouble3(node->Scale));
+		fbxNode->LclTranslation.Set(ConvertToFbxDouble3(node->Translation));
+		fbxNode->SetPreferedAngle(fbxNode->LclRotation.Get());
+
+		auto fbxSkeleton = FbxSkeleton::Create(mFbxScene, "");
+		fbxSkeleton->SetSkeletonType(FbxSkeleton::EType::eLimbNode);
+		fbxNode->SetNodeAttribute(fbxSkeleton);
+
+		fbxParentNode->AddChild(fbxNode);
+
+		// If two GFD nodes share a name, use first instance and log a warning
+		if (!mNameToFbxNodeLookup->ContainsKey(node->Name))
+			mNameToFbxNodeLookup->Add(node->Name, (IntPtr)fbxNode);
+		else
+			Trace::TraceWarning(String::Format("FbxSdkAnimationExporter: duplicate node name '{0}', animation lookup will use the first occurrence", node->Name));
+
+		if (node->HasChildren)
+		{
+			for each (auto childNode in node->Children)
+				BuildSkeletonRecursive(fbxNode, childNode);
+		}
+	}
+
+	void FbxSdkAnimationExporter::BuildSkeleton(Model^ skeleton)
+	{
+		// Skip the GFD root node itself
+		for each (auto child in skeleton->RootNode->Children)
+			BuildSkeletonRecursive(mFbxScene->GetRootNode(), child);
+	}
+
+	void FbxSdkAnimationExporter::AddPRSKeysToCurves(FbxNode* fbxNode, FbxAnimLayer* fbxAnimLayer, AnimationLayer^ layer)
+	{
+		// Resolve curve nodes / per-axis curves
+		FbxAnimCurve* tx = nullptr;
+		FbxAnimCurve* ty = nullptr;
+		FbxAnimCurve* tz = nullptr;
+		FbxAnimCurve* rx = nullptr;
+		FbxAnimCurve* ry = nullptr;
+		FbxAnimCurve* rz = nullptr;
+		FbxAnimCurve* sx = nullptr;
+		FbxAnimCurve* sy = nullptr;
+		FbxAnimCurve* sz = nullptr;
+
+		auto positionScale = layer->PositionScale;
+		auto scaleScale = layer->ScaleScale;
+
+		for each (Key^ baseKey in layer->Keys)
+		{
+			auto prsKey = dynamic_cast<PRSKey^>(baseKey);
+			if (prsKey == nullptr)
+				continue;
+
+			FbxTime time;
+			time.SetSecondDouble(prsKey->Time);
+
+			if (prsKey->HasPosition)
+			{
+				if (!tx)
+				{
+					tx = fbxNode->LclTranslation.GetCurve(fbxAnimLayer, FBXSDK_CURVENODE_COMPONENT_X, true);
+					ty = fbxNode->LclTranslation.GetCurve(fbxAnimLayer, FBXSDK_CURVENODE_COMPONENT_Y, true);
+					tz = fbxNode->LclTranslation.GetCurve(fbxAnimLayer, FBXSDK_CURVENODE_COMPONENT_Z, true);
+					tx->KeyModifyBegin();
+					ty->KeyModifyBegin();
+					tz->KeyModifyBegin();
+				}
+
+				auto pos = prsKey->Position;
+				auto px = pos.X * positionScale.X;
+				auto py = pos.Y * positionScale.Y;
+				auto pz = pos.Z * positionScale.Z;
+
+				int kx = tx->KeyAdd(time); tx->KeySetValue(kx, (float)px); tx->KeySetInterpolation(kx, FbxAnimCurveDef::eInterpolationLinear);
+				int ky = ty->KeyAdd(time); ty->KeySetValue(ky, (float)py); ty->KeySetInterpolation(ky, FbxAnimCurveDef::eInterpolationLinear);
+				int kz = tz->KeyAdd(time); tz->KeySetValue(kz, (float)pz); tz->KeySetInterpolation(kz, FbxAnimCurveDef::eInterpolationLinear);
+			}
+
+			if (prsKey->HasRotation)
+			{
+				if (!rx)
+				{
+					rx = fbxNode->LclRotation.GetCurve(fbxAnimLayer, FBXSDK_CURVENODE_COMPONENT_X, true);
+					ry = fbxNode->LclRotation.GetCurve(fbxAnimLayer, FBXSDK_CURVENODE_COMPONENT_Y, true);
+					rz = fbxNode->LclRotation.GetCurve(fbxAnimLayer, FBXSDK_CURVENODE_COMPONENT_Z, true);
+					rx->KeyModifyBegin();
+					ry->KeyModifyBegin();
+					rz->KeyModifyBegin();
+				}
+
+				// Quaternion -> Euler degrees (XYZ order, FBX default).
+				FbxAMatrix m;
+				m.SetQ(ConvertToFbxQuaternion(prsKey->Rotation));
+				FbxVector4 euler = m.GetR();
+
+				int kx = rx->KeyAdd(time); rx->KeySetValue(kx, (float)euler[0]); rx->KeySetInterpolation(kx, FbxAnimCurveDef::eInterpolationLinear);
+				int ky = ry->KeyAdd(time); ry->KeySetValue(ky, (float)euler[1]); ry->KeySetInterpolation(ky, FbxAnimCurveDef::eInterpolationLinear);
+				int kz = rz->KeyAdd(time); rz->KeySetValue(kz, (float)euler[2]); rz->KeySetInterpolation(kz, FbxAnimCurveDef::eInterpolationLinear);
+			}
+
+			if (prsKey->HasScale)
+			{
+				if (!sx)
+				{
+					sx = fbxNode->LclScaling.GetCurve(fbxAnimLayer, FBXSDK_CURVENODE_COMPONENT_X, true);
+					sy = fbxNode->LclScaling.GetCurve(fbxAnimLayer, FBXSDK_CURVENODE_COMPONENT_Y, true);
+					sz = fbxNode->LclScaling.GetCurve(fbxAnimLayer, FBXSDK_CURVENODE_COMPONENT_Z, true);
+					sx->KeyModifyBegin();
+					sy->KeyModifyBegin();
+					sz->KeyModifyBegin();
+				}
+
+				auto sc = prsKey->Scale;
+				auto sxv = sc.X * scaleScale.X;
+				auto syv = sc.Y * scaleScale.Y;
+				auto szv = sc.Z * scaleScale.Z;
+
+				int kx = sx->KeyAdd(time); sx->KeySetValue(kx, (float)sxv); sx->KeySetInterpolation(kx, FbxAnimCurveDef::eInterpolationLinear);
+				int ky = sy->KeyAdd(time); sy->KeySetValue(ky, (float)syv); sy->KeySetInterpolation(ky, FbxAnimCurveDef::eInterpolationLinear);
+				int kz = sz->KeyAdd(time); sz->KeySetValue(kz, (float)szv); sz->KeySetInterpolation(kz, FbxAnimCurveDef::eInterpolationLinear);
+			}
+		}
+
+		if (tx) { tx->KeyModifyEnd(); ty->KeyModifyEnd(); tz->KeyModifyEnd(); }
+		if (rx) { rx->KeyModifyEnd(); ry->KeyModifyEnd(); rz->KeyModifyEnd(); }
+		if (sx) { sx->KeyModifyEnd(); sy->KeyModifyEnd(); sz->KeyModifyEnd(); }
+	}
+
+	void FbxSdkAnimationExporter::BuildAnimation(Animation^ animation, String^ animationName)
+	{
+		auto stackName = Utf8String(animationName);
+		auto fbxAnimStack = FbxAnimStack::Create(mFbxScene, stackName.ToCStr());
+
+		FbxTime start; start.SetSecondDouble(0.0);
+		FbxTime stop; stop.SetSecondDouble(animation->Duration);
+		FbxTimeSpan span(start, stop);
+		fbxAnimStack->SetLocalTimeSpan(span);
+
+		auto fbxAnimLayer = FbxAnimLayer::Create(mFbxScene, "Base Layer");
+		fbxAnimStack->AddMember(fbxAnimLayer);
+
+		for each (AnimationController^ controller in animation->Controllers)
+		{
+			if (controller->TargetKind != TargetKind::Node)
+			{
+				Trace::TraceWarning(String::Format("FbxSdkAnimationExporter: skipping controller with unsupported target kind {0} on '{1}'", controller->TargetKind.ToString(), controller->TargetName));
+				continue;
+			}
+
+			IntPtr fbxNodePtr;
+			if (!mNameToFbxNodeLookup->TryGetValue(controller->TargetName, fbxNodePtr))
+			{
+				Trace::TraceWarning(String::Format("FbxSdkAnimationExporter: target bone '{0}' not found in skeleton, skipping controller", controller->TargetName));
+				continue;
+			}
+
+			auto fbxNode = (FbxNode*)fbxNodePtr.ToPointer();
+
+			for each (AnimationLayer^ layer in controller->Layers)
+			{
+				// only convert PRS key types, skip keys like Material animation keys
+				AddPRSKeysToCurves(fbxNode, fbxAnimLayer, layer);
+			}
+		}
+	}
+
+	void FbxSdkAnimationExporter::ExportFbxScene(String^ path)
+	{
+		auto fbxExporter = FbxExporter::Create(mFbxManager, "");
+		if (!fbxExporter->SetFileExportVersion(FBX_2014_00_COMPATIBLE))
+			throw gcnew FbxSdkAnimationExporterException("Failed to set FBX export version");
+
+		const bool isAsciiFbx = path->EndsWith(".ascii.fbx", StringComparison::OrdinalIgnoreCase);
+		int pFileFormat = -1;
+		if (isAsciiFbx)
+		{
+			int lFormatIndex, lFormatCount = mFbxManager->GetIOPluginRegistry()->GetWriterFormatCount();
+			for (lFormatIndex = 0; lFormatIndex < lFormatCount; lFormatIndex++)
+			{
+				if (mFbxManager->GetIOPluginRegistry()->WriterIsFBX(lFormatIndex))
+				{
+					FbxString lDesc = mFbxManager->GetIOPluginRegistry()->GetWriterFormatDescription(lFormatIndex);
+					if (lDesc.Find("ascii") >= 0)
+					{
+						pFileFormat = lFormatIndex;
+						break;
+					}
+				}
+			}
+			if (pFileFormat == -1)
+				throw gcnew FbxSdkAnimationExporterException("Failed to find FBX ASCII export format.");
+		}
+
+		if (!fbxExporter->Initialize(Utf8String(path).ToCStr(), pFileFormat, mFbxManager->GetIOSettings()))
+		{
+			auto errorMsg = gcnew String(fbxExporter->GetStatus().GetErrorString());
+			throw gcnew FbxSdkAnimationExporterException("Failed to initialize FBX exporter: " + errorMsg);
+		}
+
+		fbxExporter->Export(mFbxScene);
+		fbxExporter->Destroy();
+	}
+
+	void FbxSdkAnimationExporter::Export(Animation^ animation, Model^ skeleton, String^ animationName, String^ path, FbxSdkAnimationExporterConfig^ config)
+	{
+		Reset();
+		mConfig = config;
+
+		if (animation == nullptr)
+			throw gcnew FbxSdkAnimationExporterException("Animation is null");
+		if (skeleton == nullptr || skeleton->RootNode == nullptr)
+			throw gcnew FbxSdkAnimationExporterException("Skeleton model is null or has no root node");
+
+		auto fIos = FbxIOSettings::Create(mFbxManager, IOSROOT);
+		fIos->SetBoolProp(EXP_FBX_MATERIAL, false);
+		fIos->SetBoolProp(EXP_FBX_TEXTURE, false);
+		fIos->SetBoolProp(EXP_FBX_EMBEDDED, false);
+		fIos->SetBoolProp(EXP_FBX_SHAPE, false);
+		fIos->SetBoolProp(EXP_FBX_GOBO, false);
+		fIos->SetBoolProp(EXP_FBX_ANIMATION, true);
+		fIos->SetBoolProp(EXP_FBX_GLOBAL_SETTINGS, true);
+		mFbxManager->SetIOSettings(fIos);
+
+		mFbxScene = FbxScene::Create(mFbxManager, "");
+		if (!mFbxScene)
+			throw gcnew FbxSdkAnimationExporterException("Failed to create FBX scene");
+
+		auto& fbxGlobalSettings = mFbxScene->GetGlobalSettings();
+		fbxGlobalSettings.SetAxisSystem(FbxAxisSystem::DirectX);
+		fbxGlobalSettings.SetSystemUnit(FbxSystemUnit::m);
+
+		BuildSkeleton(skeleton);
+		BuildAnimation(animation, String::IsNullOrEmpty(animationName) ? "Take 001" : animationName);
+		ExportFbxScene(path);
+	}
+
+	void FbxSdkAnimationExporter::ExportFile(Animation^ animation, Model^ skeleton, String^ path, FbxSdkAnimationExporterConfig^ config)
+	{
+		ExportFile(animation, skeleton, nullptr, path, config);
+	}
+
+	void FbxSdkAnimationExporter::ExportFile(Animation^ animation, Model^ skeleton, String^ animationName, String^ path, FbxSdkAnimationExporterConfig^ config)
+	{
+		auto exp = gcnew FbxSdkAnimationExporter();
+		exp->Export(animation, skeleton, animationName, path, config);
+	}
+}

--- a/GFDLibrary.Conversion.FbxSdk/FbxSdkAnimationExporter.h
+++ b/GFDLibrary.Conversion.FbxSdk/FbxSdkAnimationExporter.h
@@ -1,0 +1,52 @@
+#pragma once
+
+using namespace System;
+using namespace System::Collections::Generic;
+using namespace System::Numerics;
+
+namespace GFDLibrary::Conversion::FbxSdk
+{
+	using namespace Models;
+	using namespace Animations;
+
+	public ref class FbxSdkAnimationExporterConfig
+	{
+	public:
+		inline FbxSdkAnimationExporterConfig()
+		{
+		}
+	};
+
+	public ref class FbxSdkAnimationExporterException : public Exception
+	{
+	public:
+		inline FbxSdkAnimationExporterException(String^ message) : Exception(message) {}
+	};
+
+	public ref class FbxSdkAnimationExporter sealed
+	{
+	public:
+		FbxSdkAnimationExporter();
+		~FbxSdkAnimationExporter();
+
+		static void ExportFile(Animation^ animation, Model^ skeleton, String^ path, FbxSdkAnimationExporterConfig^ config);
+		static void ExportFile(Animation^ animation, Model^ skeleton, String^ animationName, String^ path, FbxSdkAnimationExporterConfig^ config);
+
+		void Export(Animation^ animation, Model^ skeleton, String^ animationName, String^ path, FbxSdkAnimationExporterConfig^ config);
+
+	private:
+		void Reset();
+		void BuildSkeleton(Model^ skeleton);
+		void BuildSkeletonRecursive(FbxNode* fbxParentNode, Node^ node);
+		void BuildAnimation(Animation^ animation, String^ animationName);
+		void AddPRSKeysToCurves(FbxNode* fbxNode, FbxAnimLayer* fbxAnimLayer, AnimationLayer^ layer);
+		void ExportFbxScene(String^ path);
+
+		FbxManager* mFbxManager;
+		FbxScene* mFbxScene;
+
+		Dictionary<String^, IntPtr>^ mNameToFbxNodeLookup;
+
+		FbxSdkAnimationExporterConfig^ mConfig;
+	};
+}

--- a/GFDLibrary.Conversion.FbxSdk/GFDLibrary.Conversion.FbxSdk.vcxproj
+++ b/GFDLibrary.Conversion.FbxSdk/GFDLibrary.Conversion.FbxSdk.vcxproj
@@ -136,6 +136,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="FbxSdkAnimationExporter.h" />
     <ClInclude Include="FbxSdkModelPackExporter.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="Resource.h" />
@@ -143,6 +144,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="AssemblyInfo.cpp" />
+    <ClCompile Include="FbxSdkAnimationExporter.cpp" />
     <ClCompile Include="FbxSdkModelPackExporter.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>

--- a/GFDLibrary.Conversion.FbxSdk/GFDLibrary.Conversion.FbxSdk.vcxproj.filters
+++ b/GFDLibrary.Conversion.FbxSdk/GFDLibrary.Conversion.FbxSdk.vcxproj.filters
@@ -24,6 +24,9 @@
     <ClInclude Include="FbxSdkModelPackExporter.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="FbxSdkAnimationExporter.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="Utf8String.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -36,6 +39,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="FbxSdkModelPackExporter.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="FbxSdkAnimationExporter.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/GFDLibrary.Rendering.OpenGL/GFDLibrary.Rendering.OpenGL.csproj
+++ b/GFDLibrary.Rendering.OpenGL/GFDLibrary.Rendering.OpenGL.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0-windows</TargetFramework>
-    <Version>0.10.3</Version>
+    <Version>0.11.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/GFDLibrary.Tests/GFDLibrary.Tests.csproj
+++ b/GFDLibrary.Tests/GFDLibrary.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>0.10.3</Version>
+    <Version>0.11.0</Version>
     <Authors>TGE</Authors>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/GFDLibrary/GFDLibrary.csproj
+++ b/GFDLibrary/GFDLibrary.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>0.10.3</Version>
+    <Version>0.11.0</Version>
     <Authors>TGE</Authors>
     <AssemblyName>GFDLibrary</AssemblyName>
     <RootNamespace>GFDLibrary</RootNamespace>

--- a/GFDLibrary/Models/Node.cs
+++ b/GFDLibrary/Models/Node.cs
@@ -323,11 +323,11 @@ namespace GFDLibrary.Models
                 {
                     Properties = reader.ReadResource<UserPropertyDictionary>( Version );
 
-                    Console.WriteLine( Name );
+                    /*Console.WriteLine( Name );
                     foreach ( var item in Properties.Values )
                     {
                         Console.WriteLine( "\t" + item.ToUserPropertyString() );
-                    }
+                    }*/
                 }
             }
 

--- a/GFDStudio/FormatModules/AnimationExportHelper.cs
+++ b/GFDStudio/FormatModules/AnimationExportHelper.cs
@@ -1,0 +1,38 @@
+using System;
+using System.IO;
+using GFDLibrary.Animations;
+using GFDLibrary.Conversion.FbxSdk;
+using GFDLibrary.Models;
+
+namespace GFDStudio.FormatModules
+{
+    public static class AnimationExportHelper
+    {
+        public static void ExportFile( Animation animation, Model skeleton, string path )
+        {
+            ExportFile( animation, skeleton, null, path );
+        }
+
+        public static void ExportFile( Animation animation, Model skeleton, string animationName, string path )
+        {
+            if ( path.EndsWith( ".ascii.fbx", StringComparison.OrdinalIgnoreCase )
+                 || Path.GetExtension( path ).Equals( ".fbx", StringComparison.OrdinalIgnoreCase ) )
+            {
+                if ( skeleton == null )
+                    throw new InvalidOperationException( "A skeleton model is required to export an animation to FBX." );
+
+                FbxSdkAnimationExporter.ExportFile( animation, skeleton, animationName, path, new FbxSdkAnimationExporterConfig() );
+                return;
+            }
+
+            var ext = Path.GetExtension( path );
+            if ( ext.Equals( ".dae", StringComparison.OrdinalIgnoreCase )
+                 || ext.Equals( ".obj", StringComparison.OrdinalIgnoreCase ) )
+            {
+                throw new NotSupportedException( $"Exporting animations to {ext} is not supported. Use .fbx instead." );
+            }
+
+            animation.Save( path );
+        }
+    }
+}

--- a/GFDStudio/FormatModules/AssimpSceneFormatModule.cs
+++ b/GFDStudio/FormatModules/AssimpSceneFormatModule.cs
@@ -16,7 +16,7 @@ namespace GFDStudio.FormatModules
             => "3D Model";
 
         public override string[] Extensions
-            => new[] { "dae", "obj", "fbx", "ascii.fbx" };
+            => new[] { "fbx", "dae", "obj", "ascii.fbx" };
 
         public override FormatModuleUsageFlags UsageFlags
             => FormatModuleUsageFlags.ImportForEditing | FormatModuleUsageFlags.Export;

--- a/GFDStudio/GFDStudio.csproj
+++ b/GFDStudio/GFDStudio.csproj
@@ -4,7 +4,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net8.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
-    <Version>0.10.3</Version>
+    <Version>0.11.0</Version>
     <Authors>TGE</Authors>
     <Company>TGE</Company>
     <ApplicationIcon>app_data\icons\main_icon.ico</ApplicationIcon>

--- a/GFDStudio/GUI/DataViewNodes/AnimationListViewNode.cs
+++ b/GFDStudio/GUI/DataViewNodes/AnimationListViewNode.cs
@@ -1,8 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Windows.Forms;
 using GFDLibrary;
 using GFDLibrary.Animations;
+using GFDLibrary.Models;
+using GFDStudio.FormatModules;
 using Ookii.Dialogs;
 using Ookii.Dialogs.Wpf;
 
@@ -36,6 +39,32 @@ namespace GFDStudio.GUI.DataViewNodes
                         animationViewModel.Data.Save( Path.Combine( dialog.SelectedPath, animationViewModel.Text + ".ganm" ) );
                 }
             } );
+            RegisterCustomHandler( "Export", "All (FBX)", () =>
+            {
+                var skeleton = ResolveSkeletonOrPrompt();
+                if ( skeleton == null )
+                    return;
+
+                var dialog = new VistaFolderBrowserDialog();
+                if ( dialog.ShowDialog() != true )
+                    return;
+
+                foreach ( AnimationViewNode animationViewModel in Nodes )
+                {
+                    var animName = animationViewModel.Text;
+                    var fbxPath = Path.Combine( dialog.SelectedPath, animName + ".fbx" );
+                    try
+                    {
+                        AnimationExportHelper.ExportFile( animationViewModel.Data, skeleton, animName, fbxPath );
+                    }
+                    catch ( Exception ex )
+                    {
+                        MessageBox.Show( $"Failed to export {animName}: {ex.Message}", "Error",
+                            MessageBoxButtons.OK, MessageBoxIcon.Error );
+                        return;
+                    }
+                }
+            } );
             RegisterCustomHandler( "Add", "New animation", () =>
             {
                 Data.Add( new Animation() );
@@ -43,6 +72,20 @@ namespace GFDStudio.GUI.DataViewNodes
             } );
 
             base.InitializeCore();
+        }
+
+        private Model ResolveSkeletonOrPrompt()
+        {
+            var ancestor = Parent;
+            while ( ancestor != null )
+            {
+                if ( ancestor is ModelPackViewNode modelPackNode && modelPackNode.Model?.Data != null )
+                    return modelPackNode.Model.Data;
+                ancestor = ancestor.Parent;
+            }
+
+            var modelPack = ModuleImportUtilities.SelectImportFile<ModelPack>( "Select the model containing the skeleton for these animations." );
+            return modelPack?.Model;
         }
     }
 }

--- a/GFDStudio/GUI/DataViewNodes/AnimationViewNode.cs
+++ b/GFDStudio/GUI/DataViewNodes/AnimationViewNode.cs
@@ -7,6 +7,7 @@ using GFDLibrary.Animations;
 using GFDLibrary.Common;
 using GFDLibrary.Conversion;
 using GFDLibrary.Conversion.AssimpNet;
+using GFDLibrary.Models;
 using GFDStudio.FormatModules;
 using GFDStudio.GUI.TypeConverters;
 
@@ -90,6 +91,13 @@ namespace GFDStudio.GUI.DataViewNodes
         {
             Properties = new VariantUserPropertyList( Data.Properties, () => Properties = mProperties );
             RegisterExportHandler<Animation>( path => Data.Save( path ) );
+            RegisterExportHandler<AssimpScene>( path =>
+            {
+                var skeleton = ResolveSkeletonOrPrompt();
+                if ( skeleton == null )
+                    return;
+                AnimationExportHelper.ExportFile( Data, skeleton, Text, path );
+            } );
             RegisterReplaceHandler<Animation>( Resource.Load<Animation> );
             RegisterReplaceHandler<AssimpScene>( file =>
             {
@@ -131,6 +139,23 @@ namespace GFDStudio.GUI.DataViewNodes
         {
             Controllers = ( ListViewNode<AnimationController> )DataViewNodeFactory.Create( "Controllers", Data.Controllers, new[] { new ListItemNameProvider<AnimationController>( ( x, i ) => x.TargetName ) } );
             AddChildNode( Controllers );
+        }
+
+        private Model ResolveSkeletonOrPrompt()
+        {
+            // try to find animation from model pack
+            //   ModelPackViewNode -> AnimationPackViewNode -> AnimationListViewNode -> AnimationViewNode
+            // Standalone animation files have no modelpack container and will prompt user for a model
+            var container = Parent;
+            while ( container != null )
+            {
+                if ( container is ModelPackViewNode modelPackNode && modelPackNode.Model?.Data != null )
+                    return modelPackNode.Model.Data;
+                container = container.Parent;
+            }
+
+            var modelPack = ModuleImportUtilities.SelectImportFile<ModelPack>( "Select the model containing the skeleton for this animation." );
+            return modelPack?.Model;
         }
 
         private static void ImportModelAndFixTargetIds( Animation animation )

--- a/GFDStudio/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/GFDStudio/Properties/PublishProfiles/FolderProfile.pubxml
@@ -6,10 +6,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <Configuration>Release</Configuration>
     <Platform>Any CPU</Platform>
-    <PublishDir>bin\Release\net6.0-windows\publish\win-x64\</PublishDir>
+    <PublishDir>bin\Release\net8.0-windows\publish\win-x64\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
     <_TargetId>Folder</_TargetId>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>true</PublishSingleFile>


### PR DESCRIPTION
Fix a(n accidental?) regression that caused models exported via older methods such as the 3DS Maxscript to fail to properly import and leave out meshes.

Changed default export extension from .dae to .fbx.

Add animation export to FBX
- User can now choose to export an animation to fbx instead of .ganm
- User can now right click the inner "Animations" label in GAP tree view and now a third option for "Export All (FBX)" has been added
- When exporting an animation, if the animation is already located in a Model package (GMD/GFS) the animation will export directly, if the animation is not contained in a model package, the user will be prompted for a model/GMD file for the animation (which mirrors animation importing).
<img width="1482" height="1332" alt="image" src="https://github.com/user-attachments/assets/3d30e5ad-3c3d-46d3-98b3-82f2f5cee58b" />

Version number has also been bumped.